### PR TITLE
Fix missing textures on exported dynamic objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognitive3d/analytics",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "This SDK allows you to integrate your Javascript Applications with Cognitive3D, which provides analytics and insights about your VR/AR/MR project.",
   "main": "lib/cjs/index.cjs.js",
   "module": "lib/esm/index.esm.js",

--- a/src/adapters/threejs-adapter.ts
+++ b/src/adapters/threejs-adapter.ts
@@ -531,7 +531,7 @@ class C3DThreeAdapter {
             (err) => {
                 console.error(`GLTF export for ${objectName} failed:`, err);
             },
-            { binary: false } as GLTFExporterOptions
+            { binary: false, embedImages: true, onlyVisible: true, truncateDrawRange: true, maxTextureSize: 4096 } as GLTFExporterOptions
         );
     }
 }


### PR DESCRIPTION
Added `embedImages: true` to the GLTFExporter configuration inside `C3DThreeAdapter.exportObject`. This prevents the exporter from dropping image data when processing prefabs or models that use image-based texture maps instead of standard material colors.