### PR TITLE
fix(build): resolve UMD singleton bug with unified engine bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognitive3d/analytics",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "This SDK allows you to integrate your Javascript Applications with Cognitive3D, which provides analytics and insights about your VR/AR/MR project.",
   "main": "lib/cjs/index.cjs.js",
   "module": "lib/esm/index.esm.js",
@@ -30,7 +30,12 @@
       "types": "./types/adapters/wonderland-adapter.d.ts",
       "import": "./lib/esm/adapters/wonderland-adapter.esm.js",
       "require": "./lib/cjs/adapters/wonderland-adapter.cjs.js"
-    }
+    },
+    "./bundles/threejs": "./lib/c3d-bundle-threejs.umd.js",
+    "./bundles/babylon": "./lib/c3d-bundle-babylon.umd.js",
+    "./bundles/playcanvas": "./lib/c3d-bundle-playcanvas.umd.js",
+    "./bundles/wonderland": "./lib/c3d-bundle-wonderland.umd.js",
+    "./lib/*": "./lib/*"
   },
   "files": [
     "lib",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -61,6 +61,54 @@ const external = [
   'gl-matrix'
 ];
 
+// Define the unified bundles to generate
+const unifiedBundles = [
+  {
+    engine: 'threejs',
+    input: 'src/bundles/threejs.ts',
+    external: [/^three/],
+    // Handle Three.js wildcard imports for globals
+    globals: (id) => {
+      if (/^three/.test(id)) return 'THREE';
+      if (id === 'uuid') return 'uuid';
+      if (id === 'cross-fetch') return 'fetch';
+      return id;
+    }
+  },
+  {
+    engine: 'babylon',
+    input: 'src/bundles/babylon.ts',
+    external: ['babylonjs', 'babylonjs-serializers'],
+    globals: { 'babylonjs': 'BABYLON', 'babylonjs-serializers': 'BABYLON', 'uuid': 'uuid', 'cross-fetch': 'fetch' }
+  },
+  {
+    engine: 'playcanvas',
+    input: 'src/bundles/playcanvas.ts',
+    external: ['playcanvas'],
+    globals: { 'playcanvas': 'pc', 'uuid': 'uuid', 'cross-fetch': 'fetch' }
+  },
+  {
+    engine: 'wonderland',
+    input: 'src/bundles/wonderland.ts',
+    external: ['@wonderlandengine/api', 'gl-matrix'],
+    globals: { '@wonderlandengine/api': 'WL', 'gl-matrix': 'glMatrix', 'uuid': 'uuid', 'cross-fetch': 'fetch' }
+  }
+].map(bundle => ({
+  input: bundle.input,
+  output: {
+    name: 'C3D',
+    file: `lib/c3d-bundle-${bundle.engine}.umd.js`,
+    format: 'umd',
+    sourcemap: true,
+    globals: bundle.globals
+  },
+  external: bundle.external,
+  plugins: [
+    ...commonPlugins,
+    terser()
+  ]
+}));
+
 export default [
   // ESM build
   {
@@ -89,7 +137,7 @@ export default [
     external
   },
 
-  // UMD build for Main SDK
+  // UMD build for Main SDK (Kept for Core-only users)
   {
     input: 'src/index.ts',
     output: {
@@ -107,81 +155,7 @@ export default [
       terser()
     ]
   },
-     // UMD build for PlayCanvas Adapter
-  {
-    input: 'src/adapters/playcanvas-adapter.ts', 
-    output: {
-      name: 'C3DPlayCanvasAdapter',
-      file: 'lib/c3d-playcanvas-adapter.umd.js',
-      format: 'umd',
-      sourcemap: true,
-      globals: {
-        'playcanvas': 'pc'
-      }
-    },
-    external: ['playcanvas'],
-    plugins: [
-      ...commonPlugins,
-      terser()
-    ]
-  },
-  // UMD build for Three.js Adapter
-  {
-    input: 'src/adapters/threejs-adapter.ts', 
-    output: {
-        name: 'C3DThreeAdapter',
-        file: 'lib/c3d-threejs-adapter.umd.js',
-        format: 'umd',
-        sourcemap: true,
-        globals: (id) => {
-          if (/^three/.test(id)) {
-            return 'THREE';
-          }
-          return id;
-        }
-    },
-    external: [/^three/],
-    plugins: [
-        ...commonPlugins,
-        terser()
-    ]
-  },
-  // UMD build for Babylon.js Adapter
-  {
-      input: 'src/adapters/babylon-adapter.ts', 
-      output: {
-          name: 'C3DBabylonAdapter',
-          file: 'lib/c3d-babylon-adapter.umd.js',
-          format: 'umd',
-          sourcemap: true,
-          globals: {
-              'babylonjs': 'BABYLON',
-              'babylonjs-serializers': 'BABYLON'
-          }
-      },
-      external: ['babylonjs', 'babylonjs-serializers'],
-      plugins: [
-          ...commonPlugins,
-          terser()
-      ]
-  },
-  // UMD build for Wonderland Engine Adapter
-  {
-      input: 'src/adapters/wonderland-adapter.ts', 
-      output: {
-          name: 'C3DWonderlandAdapter',
-          file: 'lib/c3d-wonderland-adapter.umd.js',
-          format: 'umd',
-          sourcemap: true,
-          globals: {
-              '@wonderlandengine/api': 'WL',
-              'gl-matrix': 'glMatrix'
-          }
-      },
-      external: ['@wonderlandengine/api', 'gl-matrix'],
-      plugins: [
-          ...commonPlugins,
-          terser()
-      ]
-  }
+
+  // Inject the newly generated Unified UMD bundles
+  ...unifiedBundles
 ];

--- a/src/bundles/babylon.ts
+++ b/src/bundles/babylon.ts
@@ -1,0 +1,5 @@
+import C3D from '../index';
+import C3DBabylonAdapter from '../adapters/babylon-adapter';
+
+(C3D as any).Adapter = C3DBabylonAdapter;
+export default C3D;

--- a/src/bundles/playcanvas.ts
+++ b/src/bundles/playcanvas.ts
@@ -1,0 +1,5 @@
+import C3D from '../index';
+import C3DPlayCanvasAdapter from '../adapters/playcanvas-adapter';
+
+(C3D as any).Adapter = C3DPlayCanvasAdapter;
+export default C3D;

--- a/src/bundles/threejs.ts
+++ b/src/bundles/threejs.ts
@@ -1,0 +1,5 @@
+import C3D from '../index';
+import C3DThreeAdapter from '../adapters/threejs-adapter';
+
+(C3D as any).Adapter = C3DThreeAdapter;
+export default C3D;

--- a/src/bundles/wonderland.ts
+++ b/src/bundles/wonderland.ts
@@ -1,0 +1,5 @@
+import C3D from '../index';
+import C3DWonderlandAdapter from '../adapters/wonderland-adapter';
+
+(C3D as any).Adapter = C3DWonderlandAdapter;
+export default C3D;


### PR DESCRIPTION
Created wrapper entry points in src/bundles/ to link engine adapters directly to the SDK core.

Updated rollup.config.mjs to generate unified UMD builds (c3d-bundle-[engine].umd.js) to ensure shared memory context.

Removed legacy isolated UMD adapter builds that caused configuration sync failures.

Updated package.json exports to expose the new bundle paths.

Resolved the configuration state bug for environments using strict or legacy bundlers (e.g., Mattercraft).