### PR TITLE
WebXR SDK 2.7.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in your own API KEY.
+# .env is gitignored — never commit real keys.
+
+C3D_APPLICATION_KEY=your_application_key_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository. For install / end-user usage, see [README.md](README.md). For product docs, see [docs.cognitive3d.com/webxr](http://docs.cognitive3d.com/webxr/get-started/).
+
+## Project overview
+
+`@cognitive3d/analytics` — a WebXR analytics SDK for VR/AR/MR applications. The core is engine-agnostic; thin adapters integrate with Three.js, Babylon.js, PlayCanvas, and Wonderland Engine. The SDK records session data (gaze, dynamic objects, custom events, sensors, controller input, HMD orientation, exit polls) and batches it to the Cognitive3D backend.
+
+## Repository layout
+
+- [src/](src/) — TypeScript source. Engine-agnostic core.
+- [src/adapters/](src/adapters/) — one file per engine (`threejs-adapter.ts`, `babylon-adapter.ts`, `playcanvas-adapter.ts`, `wonderland-adapter.ts`). Classes follow the `C3DXxxAdapter` naming pattern.
+- [src/bundles/](src/bundles/) — entry points for the pre-built UMD bundles (one per engine).
+- [src/utils/](src/utils/) — WebXR session management, HMD orientation, controller tracker, controller input tracker, boundary, framerate, profiler, environment detection.
+- [__tests__/](__tests__/) — Jest tests, `*-test.js` suffix (JS, not TS).
+- [lib/](lib/), [types/](types/) — **generated** by `npm run build`. Do not edit or commit hand-modifications here.
+- [settings.js](settings.js) — test-only config. Reads `C3D_APPLICATION_KEY` from the environment.
+- [rollup.config.mjs](rollup.config.mjs) — build config for all output formats.
+- [jest.config.js](jest.config.js) — loads `dotenv/config` so tests pick up `.env`.
+
+## Build and test commands
+
+From [package.json](package.json):
+
+- `npm run build` — full build: `build:js` (rollup) + `build:types` (`tsc -p tsconfig.dts.json`).
+- `npm run build:js` — rollup only. Emits ESM into `lib/esm/`, CJS into `lib/cjs/`, UMD into `lib/`.
+- `npm run dev` — rollup in watch mode.
+- `npm test` — Jest. Requires `.env` with `C3D_APPLICATION_KEY` (loaded via `dotenv/config`).
+- `npm run test:browser` / `npm run test:node` — split configs for environment-specific tests.
+
+Note: `prepare` runs `build`, so `npm install` triggers a full build automatically.
+
+Node 20+ is required (both locally and in CI).
+
+## Output formats and exports
+
+Each entry ships in three formats:
+- **ESM** — `lib/esm/*.esm.js`
+- **CJS** — `lib/cjs/*.cjs.js`
+- **UMD** — `lib/c3d.umd.js` (core only) plus per-engine bundles at `lib/c3d-bundle-{threejs,babylon,playcanvas,wonderland}.umd.js`
+
+Rollup inputs are defined in [rollup.config.mjs](rollup.config.mjs) (`input` map for ESM/CJS/adapters; `unifiedBundles` array for UMD bundles). The `exports` and `typesVersions` blocks in [package.json](package.json) must stay in sync with rollup inputs — when adding or renaming an adapter, update **both**.
+
+## Core architectural patterns
+
+**Singleton core.** `coreInstance` from [src/core.ts](src/core.ts) holds global analytics state. The `C3D` class in [src/index.ts](src/index.ts) composes feature modules around it and exposes `c3d.core`.
+
+**Adapter pattern.** Engine-specific code lives *only* in [src/adapters/](src/adapters/) and [src/bundles/](src/bundles/). [src/index.ts](src/index.ts) and [src/core.ts](src/core.ts) must stay engine-agnostic — do not import `three`, `babylonjs`, `playcanvas`, or `@wonderlandengine/api` from them. Engine SDKs are declared as optional peer deps in [package.json](package.json) and marked `external` in rollup.
+
+**Feature modules.** Gaze, custom events, dynamic objects, sensors, exit poll, FPS, HMD orientation, profiler, controller tracker, controller input, boundary — each is its own class, instantiated by the `C3D` constructor. To add a new feature: add the class under [src/](src/), instantiate it in the `C3D` constructor in [src/index.ts](src/index.ts), and add a test under [__tests__/](__tests__/).
+
+**Batch/flush semantics.** Gaze samples, dynamic-object snapshots, custom events, and sensor readings are batched and auto-flushed. Defaults in [settings.js](settings.js): `gazeBatchSize: 256`, `dynamicDataLimit: 512`, `customEventBatchSize: 256`, `sensorDataLimit: 512`. Do not bypass the batch queues to send data directly — it breaks payload shape and flush lifecycle.
+
+**Session lifecycle.** `setScene(sceneName)` → `startSession()` → tracking → `endSession()`. `isSessionActive` gates recording. A fresh session ID and timestamp are generated per session.
+
+**WebXR reference-space fallback.** [src/utils/webxr.ts](src/utils/webxr.ts) requests `local-floor` and falls back to `local` if unavailable. Intentional — preserve this chain if touching XR init.
+
+**Deterministic dynamic-object IDs.** Dynamic objects use UUIDv5 with a fixed namespace so IDs are stable across sessions (commit `89ff9f1`). Do not change the namespace — it would invalidate historical data in the Cognitive3D dashboard.
+
+**Coordinate system for controllers.** Controller transforms are converted to LHS (commit `40b91e9`). Keep this conversion when modifying controller or hand tracking code.
+
+## Conventions
+
+- TypeScript strict mode ([tsconfig.json](tsconfig.json): `target: es6`, `module: esnext`).
+- Classes: PascalCase. Methods and properties: camelCase. Adapters: `C3DXxxAdapter`.
+- One main class per file; interfaces co-located with the class that uses them.
+- 2-space indentation. Semicolons required.
+- Tests live in [__tests__/](__tests__/) with a `*-test.js` suffix (JS, transpiled via babel-jest — not `.ts`).
+- Do not edit [lib/](lib/) or [types/](types/) — both are regenerated by `npm run build`.
+- Avoid adding `// @ts-ignore` unless working around a known circular-type edge case (there are a few already in [src/index.ts](src/index.ts)).
+
+## External dependencies
+
+Runtime dependencies (kept small; see [package.json](package.json)):
+- `@fingerprintjs/fingerprintjs` — device ID, browser-only
+- `cross-fetch` — unified fetch for Node and browser
+- `jszip` — scene export
+- `uuid`, `tslib`
+
+Engine SDKs (`three`, `babylonjs`, `playcanvas`, `@wonderlandengine/api`, `gl-matrix`) are **optional peer deps**. Never move them into `dependencies`.
+
+Backend API host is configured in [settings.js](settings.js): `data.cognitive3d.com` (prod) or `data.c3ddev.com` (dev).
+
+## CI and publishing
+
+- [.github/workflows/npm-publish.yml](.github/workflows/npm-publish.yml) runs on pushes to `main` and `development`.
+- `main` → public NPM release at the current `version` in [package.json](package.json).
+- `development` → `dev` tag with a commit-SHA suffix (e.g., `2.7.0-dev.a1b2c3d`).
+- NPM auth via OIDC. Tests must pass and require `C3D_APPLICATION_KEY` as a repo secret.
+
+## Common pitfalls
+
+Do not:
+- Import engine SDKs (`three`, `babylonjs`, `playcanvas`, `@wonderlandengine/api`) from [src/index.ts](src/index.ts) or [src/core.ts](src/core.ts). They belong only in adapters and bundles.
+- Edit [lib/](lib/) or [types/](types/) by hand — both are generated.
+- Add a new entry point without updating both [rollup.config.mjs](rollup.config.mjs) and the `exports` + `typesVersions` blocks in [package.json](package.json).
+- Change the UUIDv5 namespace used for dynamic objects — it would invalidate historical data.
+- Bypass the batch queues to send gaze / event / sensor / dynamic data directly.
+- Move engine SDKs from `peerDependencies` into `dependencies`.
+
+Do:
+- Run `npm run build` before publishing (the `prepare` script handles this on install automatically).
+- Place new tests under [__tests__/](__tests__/) with a `-test.js` suffix, and make sure `.env` contains `C3D_APPLICATION_KEY`.
+- When adding an adapter: create the file in [src/adapters/](src/adapters/), create the matching bundle entry in [src/bundles/](src/bundles/), update [rollup.config.mjs](rollup.config.mjs) (`input` + `unifiedBundles`), and update [package.json](package.json) (`exports` + `typesVersions`).

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Welcome!  This SDK allows you to integrate your JavaScript/ TypeScript/ WebXR Ap
 </div>
 
 ## ✅ Requirement(s)
-Node.js version 20 or higher. To check your current version: 
+Node.js version 20 or higher. To check your current version:
 ```
 node --version
 ```
 
 ## 🔧 Installation 
-You can add Cognitive3D to your project in two ways. 
+You can add Cognitive3D to your project in two ways.
 ### Option 1. Install from NPM
-Inside your project's terminal, run the following command 
+Inside your project's terminal, run the following command
 ```
 npm install @cognitive3d/analytics
 ```
@@ -80,11 +80,8 @@ It supports a wide range of development environments by providing multiple modul
 * **ES Module**: Modern module standard, used by most bundlers and modern Node.js.
 * **CommonJS**: Compatible with older Node.js environments.
 
-
 ## 📚 Documentation 
 The **[Cognitive3D WebXR SDK documentation](http://docs.cognitive3d.com/webxr/get-started/)** explains how to integrate the SDK, track user experiences, export scenes, track dynamic objects, and more.
 
-
 ## 🎮 Sample Projects
-For more detailed examples and complete project integrations (Playcanvas, ThreeJS, Wonderland Engine), please see our **[sample applications repository](https://github.com/CognitiveVR/c3d-webxr-sample-apps)** 
-
+For more detailed examples and complete project integrations (Mattercraft, ThreeJS, Wonderland Engine, etc..), please see our **[sample applications repository](https://github.com/CognitiveVR/c3d-webxr-sample-apps)** 

--- a/__tests__/dynamic-test.js
+++ b/__tests__/dynamic-test.js
@@ -413,3 +413,95 @@ test('End Engagements When an Object is Removed from the Scene', async () => {
 });
 
 
+const UUID_V5_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+test('registerObject produces the same deterministic UUID across fresh C3D instances', async () => {
+	const pos = [0, 0, 0];
+	const rot = [0, 0, 0, 1];
+
+	const c3dA = new C3DAnalytics(settings);
+	c3dA.setScene(scene1);
+	c3dA.startSession();
+	const idA = c3dA.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	await expect(c3dA.endSession()).resolves.toEqual(200);
+
+	const c3dB = new C3DAnalytics(settings);
+	c3dB.setScene(scene1);
+	c3dB.startSession();
+	const idB = c3dB.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	await expect(c3dB.endSession()).resolves.toEqual(200);
+
+	expect(idA).toBe(idB);
+	expect(idA).toMatch(UUID_V5_REGEX);
+});
+
+test('registerObject returns distinct UUIDs for different names in the same scene', async () => {
+	const c3d = new C3DAnalytics(settings);
+	c3d.setScene(scene1);
+	c3d.startSession();
+	const pos = [0, 0, 0];
+	const rot = [0, 0, 0, 1];
+
+	const id1 = c3d.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	const id2 = c3d.dynamicObject.registerObject("object2", "lamp", pos, rot);
+
+	expect(id1).not.toBe(id2);
+	expect(id1).toMatch(UUID_V5_REGEX);
+	expect(id2).toMatch(UUID_V5_REGEX);
+	await expect(c3d.endSession()).resolves.toEqual(200);
+});
+
+(scene2 ? test : test.skip)('registerObject returns distinct UUIDs for the same name in different scenes', async () => {
+	const pos = [0, 0, 0];
+	const rot = [0, 0, 0, 1];
+
+	const c3dA = new C3DAnalytics(settings);
+	c3dA.setScene(scene1);
+	c3dA.startSession();
+	const idSceneA = c3dA.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	await expect(c3dA.endSession()).resolves.toEqual(200);
+
+	const c3dB = new C3DAnalytics(settings);
+	c3dB.setScene(scene2);
+	c3dB.startSession();
+	const idSceneB = c3dB.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	await expect(c3dB.endSession()).resolves.toEqual(200);
+
+	expect(idSceneA).not.toBe(idSceneB);
+});
+
+test('registerObject returns distinct UUIDs when meshname differs', async () => {
+	const c3d = new C3DAnalytics(settings);
+	c3d.setScene(scene1);
+	c3d.startSession();
+	const pos = [0, 0, 0];
+	const rot = [0, 0, 0, 1];
+
+	const idLamp = c3d.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	const idChair = c3d.dynamicObject.registerObject("object1", "chair", pos, rot);
+
+	expect(idLamp).not.toBe(idChair);
+	await expect(c3d.endSession()).resolves.toEqual(200);
+});
+
+test('registerObject with duplicate (name, meshname) returns the existing id without adding a duplicate entry', async () => {
+	const c3d = new C3DAnalytics(settings);
+	c3d.setScene(scene1);
+	c3d.startSession();
+	const pos = [0, 0, 0];
+	const rot = [0, 0, 0, 1];
+
+	const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+	const first = c3d.dynamicObject.registerObject("object1", "lamp", pos, rot);
+	const second = c3d.dynamicObject.registerObject("object1", "lamp", pos, rot);
+
+	expect(second).toBe(first);
+	expect(c3d.dynamicObject.objectIds.length).toBe(1);
+	expect(c3d.dynamicObject.manifestEntries.length).toBe(1);
+	expect(warnSpy).toHaveBeenCalled();
+
+	warnSpy.mockRestore();
+	await expect(c3d.endSession()).resolves.toEqual(200);
+});
+

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
         "handtracking",
         "questionset",
         "cooldown",
-        "engagementtype"
+        "engagementtype",
+        "controllerinputs"
     ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
         "questionset",
         "cooldown",
         "engagementtype",
-        "controllerinputs"
+        "controllerinputs",
+        "Mattercraft"
     ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  // Tells Jest to use babel-jest to transform JavaScript and TypeScript files.
   transform: {
     '^.+\\.(t|j)sx?$': 'babel-jest',
   },
+  setupFiles: ['dotenv/config'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "babylonjs": ">=5.0.0",
         "babylonjs-serializers": ">=5.0.0",
         "cross-env": "^7.0.3",
+        "dotenv": "^17.4.2",
         "gl-matrix": "^3.4.3",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
@@ -5429,6 +5430,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.6.4",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognitive3d/analytics",
-      "version": "2.6.4",
+      "version": "2.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,9 +4656,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4914,9 +4914,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8026,9 +8026,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8614,9 +8614,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9036,9 +9036,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9514,9 +9514,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -9979,9 +9979,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "babylonjs": ">=5.0.0",
     "babylonjs-serializers": ">=5.0.0",
     "cross-env": "^7.0.3",
+    "dotenv": "^17.4.2",
     "gl-matrix": "^3.4.3",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.6.4",
+  "version": "2.7.0",
   "description": "This SDK allows you to integrate your Javascript Applications with Cognitive3D, which provides analytics and insights about your VR/AR/MR project.",
   "main": "lib/cjs/index.cjs.js",
   "module": "lib/esm/index.esm.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,8 +20,9 @@ export interface Settings {
     customEventBatchSize?: number;
     gazeBatchSize?: number;
     GazeInterval?: number;
-    HMDType?: string; 
+    HMDType?: string;
     gazeTrackingSource?: 'webxr' | 'engine';
+    fallbackController?: string;
     allSceneData?: SceneConfig[];
     [key: string]: unknown; // Allow flexibility
 }
@@ -38,8 +39,9 @@ class Config {
     public gazeBatchSize: number;
     public GazeInterval: number;
     public allSceneData: SceneConfig[];
-    public HMDType?: string; 
+    public HMDType?: string;
     public gazeTrackingSource: 'webxr' | 'engine';
+    public fallbackController?: string;
     [key: string]: any; // Index signature for dynamic access in setter
 
     constructor() {
@@ -79,7 +81,8 @@ class Config {
         const keys: (keyof Settings)[] = [
             'SDKVersion', 'networkHost', 'APIKey', 'networkVersion',
             'sensorDataLimit', 'dynamicDataLimit', 'customEventBatchSize',
-            'gazeBatchSize', 'GazeInterval', 'HMDType', 'allSceneData', 'gazeTrackingSource'
+            'gazeBatchSize', 'GazeInterval', 'HMDType', 'allSceneData', 'gazeTrackingSource',
+            'fallbackController'
         ];
 
         for (const key of keys) {

--- a/src/dynamicobject.ts
+++ b/src/dynamicobject.ts
@@ -1,7 +1,12 @@
-import { v4 as uuidv4 } from 'uuid';
+import { v5 as uuidv5 } from 'uuid';
 import Network from './network';
 import { CognitiveVRAnalyticsCore } from './core';
 import CustomEvents from './customevent';
+
+// Fixed namespace so that uuidv5 output is stable across SDK consumers and
+// sessions. Do not change this — changing it would invalidate every
+// previously-generated dynamic object ID.
+const C3D_DYNAMIC_OBJECT_NAMESPACE = 'c3d7ef2b-8a1d-4e5c-9b3f-7a6e2d8c4f10';
 
 export interface DynamicObjectId {
     id: string;
@@ -159,13 +164,23 @@ class DynamicObject {
             fileType = scaleOrFileType;
         }
         
-        let newObjectId = this.dynamicObjectId(uuidv4(), meshname);
+        const sceneId = this.core.sceneData.sceneId || '';
+        const seed = `${sceneId}::${name}::${meshname}`;
+        const deterministicId = uuidv5(seed, C3D_DYNAMIC_OBJECT_NAMESPACE);
+
+        const existing = this.objectIds.find(o => o.id === deterministicId);
+        if (existing) {
+            console.warn(`DynamicObject.registerObject: "${name}" + "${meshname}" already registered in this scene; returning existing id.`);
+            return existing.id;
+        }
+
+        let newObjectId = this.dynamicObjectId(deterministicId, meshname);
         this.objectIds.push(newObjectId);
         const finalFileType = fileType || "gltf";
         let dome = this.dynamicObjectManifestEntry(newObjectId.id, name, meshname, finalFileType);
         this.manifestEntries.push(dome);
         this.fullManifest.push(dome);
-        
+
         let props = [{ "enabled": true }];
         this.addSnapshot(newObjectId.id, position, rotation, scale, props);
 

--- a/src/dynamicobject.ts
+++ b/src/dynamicobject.ts
@@ -19,6 +19,8 @@ export interface ManifestEntry {
     name: string;
     mesh: string;
     fileType: string;
+    controllerType?: string;
+    properties?: Array<Record<string, any>>;
 }
 
 export interface EngagementEvent {
@@ -50,6 +52,14 @@ interface ManifestPayloadEntry {
     name: string;
     mesh: string;
     fileType: string;
+    controllerType?: string;
+    properties?: Array<Record<string, any>>;
+}
+
+export interface ButtonState {
+    buttonPercent: number;
+    x?: number;
+    y?: number;
 }
 
 export interface SnapshotPayload {
@@ -59,7 +69,8 @@ export interface SnapshotPayload {
     r: number[];
     s?: number[];
     engagements?: EngagementPayload[];
-    properties?: any; 
+    properties?: any;
+    buttons?: Record<string, ButtonState>;
 }
 
 export interface Snapshot {
@@ -68,8 +79,9 @@ export interface Snapshot {
     time: number;
     id: string;
     scale?: number[] | null;
-    properties?: any; 
+    properties?: any;
     engagements?: EngagementPayload[];
+    buttons?: Record<string, ButtonState>;
 }
 
 export interface TrackedObjectEntry {
@@ -300,11 +312,14 @@ class DynamicObject {
     private _buildManifest(): Record<string, ManifestPayloadEntry> {
         let manifest: Record<string, ManifestPayloadEntry> = {};
         for (let element of this.manifestEntries) {
-            manifest[element.id] = {
+            const entry: ManifestPayloadEntry = {
                 name: element.name,
                 mesh: element.mesh,
                 fileType: "gltf"
             };
+            if (element.controllerType) entry.controllerType = element.controllerType;
+            if (element.properties) entry.properties = element.properties;
+            manifest[element.id] = entry;
         }
         return manifest;
     }
@@ -323,25 +338,74 @@ class DynamicObject {
             }
             if (element.engagements && element.engagements.length) { entry['engagements'] = element.engagements; }
             if (element.properties) { entry['properties'] = element.properties; }
+            if (element.buttons) { entry['buttons'] = element.buttons; }
             data.push(entry);
         }
         return data;
     }
 
-    dynamicObjectSnapshot(position: number[], rotation: number[], objectId: string, scale?: number[] | null, properties?: any): Snapshot {
+    dynamicObjectSnapshot(position: number[], rotation: number[], objectId: string, scale?: number[] | null, properties?: any, buttons?: Record<string, ButtonState>): Snapshot {
         let ss: Snapshot = {
             position: position,
             rotation: rotation,
             time: this.core.getTimestamp(),
             id: objectId
         };
-        if (scale) {
-            ss.scale = scale;
-        }
-        if (properties) {
-            ss.properties = properties;
-        }
+        if (scale) { ss.scale = scale; }
+        if (properties) { ss.properties = properties; }
+        if (buttons) { ss.buttons = buttons; }
         return ss;
+    }
+
+    registerControllerObject(
+        name: string, meshname: string, customid: string,
+        position: number[], rotation: number[],
+        controllerType: string, handedness: 'left' | 'right'
+    ): string {
+        for (let i = 0; i < this.objectIds.length; i++) {
+            if (this.objectIds[i].id === customid) {
+                console.log("DynamicObject.registerControllerObject object id " + customid + " already registered");
+                return customid;
+            }
+        }
+        let registerId = this.dynamicObjectId(customid, meshname);
+        this.objectIds.push(registerId);
+
+        const dome: ManifestEntry = {
+            id: customid,
+            name,
+            mesh: meshname,
+            fileType: 'gltf',
+            controllerType,
+            properties: [{ controller: handedness }],
+        };
+        this.manifestEntries.push(dome);
+        this.fullManifest.push(dome);
+
+        this.addSnapshot(customid, position, rotation, null, [{ enabled: true }]);
+
+        if (this.core.isSessionActive && (this.snapshots.length + this.manifestEntries.length >= this.core.config.dynamicDataLimit)) {
+            this.sendData();
+        }
+        return customid;
+    }
+
+    addInputSnapshot(
+        objectId: string, position: number[], rotation: number[],
+        buttons?: Record<string, ButtonState> | null,
+        properties?: any
+    ): void {
+        const foundId = this.objectIds.some(e => objectId === e.id);
+        if (!foundId) {
+            console.warn("DynamicObject::addInputSnapshot cannot find objectId " + objectId);
+            return;
+        }
+        const snapshot = this.dynamicObjectSnapshot(position, rotation, objectId, null, properties, buttons ?? undefined);
+        this.snapshots.push(snapshot);
+
+        if (this.core.isSessionActive && (this.snapshots.length + this.manifestEntries.length >= this.core.config.dynamicDataLimit)) {
+            this.sendData();
+        }
     }
 
     dynamicObjectEngagementEvent(id: string | null, engagementName: string, engagementNumber: number): EngagementEvent {

--- a/src/dynamicobject.ts
+++ b/src/dynamicobject.ts
@@ -179,16 +179,31 @@ class DynamicObject {
         const sceneId = this.core.sceneData.sceneId || '';
         const seed = `${sceneId}::${name}::${meshname}`;
         const deterministicId = uuidv5(seed, C3D_DYNAMIC_OBJECT_NAMESPACE);
+        const finalFileType = fileType || "gltf";
 
         const existing = this.objectIds.find(o => o.id === deterministicId);
         if (existing) {
+            if (!existing.used) {
+                existing.used = true;
+                let manifestEntry = this.fullManifest.find(entry => entry.id === existing.id);
+                if (!manifestEntry) {
+                    manifestEntry = this.dynamicObjectManifestEntry(existing.id, name, meshname, finalFileType);
+                    this.fullManifest.push(manifestEntry);
+                }
+                if (!this.manifestEntries.some(entry => entry.id === existing.id)) {
+                    this.manifestEntries.push(manifestEntry);
+                }
+                this.addSnapshot(existing.id, position, rotation, scale, [{ "enabled": true }]);
+                if (this.core.isSessionActive && (this.snapshots.length + this.manifestEntries.length >= this.core.config.dynamicDataLimit)) {
+                    this.sendData();
+                }
+            }
             console.warn(`DynamicObject.registerObject: "${name}" + "${meshname}" already registered in this scene; returning existing id.`);
             return existing.id;
         }
 
         let newObjectId = this.dynamicObjectId(deterministicId, meshname);
         this.objectIds.push(newObjectId);
-        const finalFileType = fileType || "gltf";
         let dome = this.dynamicObjectManifestEntry(newObjectId.id, name, meshname, finalFileType);
         this.manifestEntries.push(dome);
         this.fullManifest.push(dome);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import DynamicObject from './dynamicobject';
 import FPSTracker, { FPSMetrics } from './utils/Framerate';
 import HMDOrientationTracker, { OrientationData } from './utils/HMDOrientation';
 import Profiler from './utils/Profiler';
-import ControllerTracker from './utils/ControllerTracker'; 
+import ControllerTracker from './utils/ControllerTracker';
+import ControllerInputTracker from './utils/ControllerInputTracker';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import BoundaryTracker from './utils/BoundaryTracker';
 import { Settings, SceneConfig } from './config';
@@ -46,6 +47,7 @@ class C3D {
   public hmdOrientation: HMDOrientationTracker;
   public profiler: Profiler;
   public controllerTracker: ControllerTracker;
+  public controllerInputTracker: ControllerInputTracker;
   public sensor: Sensor;
   public exitpoll: ExitPoll;
   public dynamicObject: DynamicObject;
@@ -78,6 +80,7 @@ class C3D {
     this.hmdOrientation = new HMDOrientationTracker();
     this.profiler = new Profiler(self);
     this.controllerTracker = new ControllerTracker(self);
+    this.controllerInputTracker = new ControllerInputTracker(self);
     this.sensor = new Sensor(this.core);
     this.exitpoll = new ExitPoll(this.core, this.customEvent);
     this.dynamicObject = new DynamicObject(this.core, this.customEvent);
@@ -164,6 +167,7 @@ class C3D {
       }
 
       this.controllerTracker.start(xrSession);
+      this.controllerInputTracker.start(xrSession);
 
       if (sessionInfo && sessionInfo.boundedReferenceSpace) {
           this.boundaryTracker.start(xrSession, sessionInfo.boundedReferenceSpace);
@@ -190,52 +194,32 @@ class C3D {
       const features = getEnabledFeatures(xrSession);
       this.setDeviceProperty("HandTracking", features.handTracking);
       this.setDeviceProperty("EyeTracking", features.eyeTracking);
+      this.setSessionProperty("c3d.device.controllerinputs.enabled", true);
+      if (features.handTracking) {
+          this.setSessionProperty("c3d.app.handtracking.enabled", true);
+      }
     }
     else{
         console.warn("C3D: No XR session was provided. Gaze data will not be tracked.");
     }
 
-    if (xrSession && xrSession.inputSources) { 
+    if (xrSession && xrSession.inputSources) {
         const hmdInfo = getHMDInfo(xrSession.inputSources);
         if (hmdInfo) {
             this.setDeviceProperty('VRModel', hmdInfo.VRModel);
             this.setDeviceProperty('VRVendor', hmdInfo.VRVendor);
-        } 
+        }
 
-        const checkInputType = (sources: XRInputSourceArray) => {
-            const hasHand = Array.from(sources).some(source => source.hand);
-            const hasController = Array.from(sources).some(source => !source.hand && source.targetRayMode === 'tracked-pointer');
-            
-            let currentInputType: 'none' | 'hand' | 'controller' = 'none';
-            if (hasHand) {
-                currentInputType = 'hand';
-            } else if (hasController) {
-                currentInputType = 'controller';
-            }
-
-            if (currentInputType !== this.lastInputType) {
-                this.customEvent.send('c3d.input.tracking.changed', [0,0,0], {
-                    "Previously Tracking": this.lastInputType,
-                    "Now Tracking": currentInputType
-                });
-                this.lastInputType = currentInputType;
-            }
-        };
-
-        checkInputType(xrSession.inputSources);
-
-        xrSession.addEventListener('inputsourceschange', (event: XRInputSourcesChangeEvent) => {            
+        xrSession.addEventListener('inputsourceschange', (event: XRInputSourcesChangeEvent) => {
             // @ts-ignore
             const xrEvent = event as XRInputSourcesChangeEvent;
-            checkInputType(xrEvent.session.inputSources);
-            
             const newHmdInfo = getHMDInfo(xrEvent.session.inputSources);
             if (newHmdInfo) {
                 this.setDeviceProperty('VRModel', newHmdInfo.VRModel);
                 this.setDeviceProperty('VRVendor', newHmdInfo.VRVendor);
             }
         });
-    }      
+    }
 
     this.core.setSessionStatus = true;
     this.core.getSessionTimestamp();
@@ -258,7 +242,10 @@ class C3D {
       }
       
       if (this.controllerTracker) {
-          this.controllerTracker.stop(); 
+          this.controllerTracker.stop();
+      }
+      if (this.controllerInputTracker) {
+          this.controllerInputTracker.stop();
       }
       if (this.boundaryTracker) {
           this.boundaryTracker.stop(); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ class C3D {
     this.hmdOrientation = new HMDOrientationTracker();
     this.profiler = new Profiler(self);
     this.controllerTracker = new ControllerTracker(self);
-    this.controllerInputTracker = new ControllerInputTracker(self);
+    this.controllerInputTracker = new ControllerInputTracker(self, this.core.config.fallbackController);
     this.sensor = new Sensor(this.core);
     this.exitpoll = new ExitPoll(this.core, this.customEvent);
     this.dynamicObject = new DynamicObject(this.core, this.customEvent);

--- a/src/utils/ControllerInputTracker.ts
+++ b/src/utils/ControllerInputTracker.ts
@@ -1,0 +1,338 @@
+import { isBrowser } from './environment';
+import { ButtonState } from '../dynamicobject';
+import { SessionPropertyValue } from '../core';
+
+interface C3DInstance {
+    customEvent: {
+        send: (name: string, position: number[], properties?: Record<string, SessionPropertyValue>) => void;
+    };
+    dynamicObject: {
+        registerControllerObject: (
+            name: string, meshname: string, customid: string,
+            position: number[], rotation: number[],
+            controllerType: string, handedness: 'left' | 'right'
+        ) => string;
+        addInputSnapshot: (
+            id: string, position: number[], rotation: number[],
+            buttons?: Record<string, ButtonState> | null,
+            properties?: any
+        ) => void;
+        objectIds: Array<{ id: string; used: boolean; meshname: string }>;
+    };
+    xrSessionManager: { referenceSpace: XRReferenceSpace | null } | null;
+    lastInputType: 'none' | 'hand' | 'controller';
+}
+
+interface ControllerProfile {
+    mesh: (h: 'left' | 'right') => string;
+    controllerType: (h: 'left' | 'right') => string;
+}
+
+const CONTROLLER_PROFILE_MAP: Record<string, ControllerProfile> = {
+    'meta-quest-touch-plus': {
+        mesh: h => h === 'left' ? 'QuestPlusTouchLeft' : 'QuestPlusTouchRight',
+        controllerType: h => h === 'left' ? 'quest_plus_touch_left' : 'quest_plus_touch_right',
+    },
+    'meta-quest-touch-pro': {
+        mesh: h => h === 'left' ? 'QuestProTouchLeft' : 'QuestProTouchRight',
+        controllerType: h => h === 'left' ? 'quest_pro_touch_left' : 'quest_pro_touch_right',
+    },
+    'oculus-touch-v3': {
+        mesh: h => h === 'left' ? 'OculusQuestTouchLeft' : 'OculusQuestTouchRight',
+        controllerType: h => h === 'left' ? 'oculus_quest_touch_left' : 'oculus_quest_touch_right',
+    },
+    'oculus-touch-v2': {
+        mesh: h => h === 'left' ? 'OculusQuestTouchLeft' : 'OculusQuestTouchRight',
+        controllerType: h => h === 'left' ? 'oculus_quest_touch_left' : 'oculus_quest_touch_right',
+    },
+    'oculus-touch': {
+        mesh: h => h === 'left' ? 'OculusRiftTouchLeft' : 'OculusRiftTouchRight',
+        controllerType: h => h === 'left' ? 'oculus_rift_controller_left' : 'oculus_rift_controller_right',
+    },
+    'htc-vive-focus-3': {
+        mesh: h => h === 'left' ? 'ViveFocusControllerLeft' : 'ViveFocusControllerRight',
+        controllerType: h => h === 'left' ? 'vive_focus_controller_left' : 'vive_focus_controller_right',
+    },
+    'htc-vive': {
+        mesh: _ => 'ViveController',
+        controllerType: _ => 'vive_controller',
+    },
+    'valve-index': {
+        mesh: h => h === 'left' ? 'SteamIndexLeft' : 'SteamIndexRight',
+        controllerType: h => h === 'left' ? 'steam_index_left' : 'steam_index_right',
+    },
+    'microsoft-mixed-reality': {
+        mesh: h => h === 'left' ? 'WindowsMixedRealityLeft' : 'WindowsMixedRealityRight',
+        controllerType: h => h === 'left' ? 'windows_mixed_reality_controller_left' : 'windows_mixed_reality_controller_right',
+    },
+    'hp-mixed-reality': {
+        mesh: h => h === 'left' ? 'WindowsMixedRealityLeft' : 'WindowsMixedRealityRight',
+        controllerType: h => h === 'left' ? 'windows_mixed_reality_controller_left' : 'windows_mixed_reality_controller_right',
+    },
+    'pico-neo3-controller': {
+        mesh: h => h === 'left' ? 'PicoNeo3ControllerLeft' : 'PicoNeo3ControllerRight',
+        controllerType: h => h === 'left' ? 'pico_neo_3_eye_controller_left' : 'pico_neo_3_eye_controller_right',
+    },
+    'pico-4-controller': {
+        mesh: h => h === 'left' ? 'PicoNeo4ControllerLeft' : 'PicoNeo4ControllerRight',
+        controllerType: h => h === 'left' ? 'pico_neo_4_eye_controller_left' : 'pico_neo_4_eye_controller_right',
+    },
+};
+
+function resolveControllerProfile(profiles: readonly string[]): ControllerProfile | null {
+    for (const profile of profiles) {
+        const lower = profile.toLowerCase();
+        for (const key of Object.keys(CONTROLLER_PROFILE_MAP)) {
+            if (lower.includes(key)) return CONTROLLER_PROFILE_MAP[key];
+        }
+    }
+    return null;
+}
+
+const ANALOG_THROTTLE_MS = 100;
+const JOYSTICK_MIN_MAGNITUDE = 0.05;
+
+class ControllerInputTracker {
+    private c3d: C3DInstance;
+    private xrSession: XRSession | null = null;
+    private isTracking = false;
+    private animationFrameHandle: number | null = null;
+
+    private registeredIds = new Set<string>();
+    private lastButtons = new Map<string, Record<string, ButtonState>>();
+    private lastAnalogTime = new Map<string, number>();
+    private lastPoses = new Map<string, { pos: number[]; rot: number[] }>();
+
+    constructor(c3dInstance: C3DInstance) {
+        this.c3d = c3dInstance;
+        this._onFrame = this._onFrame.bind(this);
+    }
+
+    start(xrSession: XRSession): void {
+        if (!isBrowser || this.isTracking) return;
+        this.xrSession = xrSession;
+        this.isTracking = true;
+        this.animationFrameHandle = xrSession.requestAnimationFrame(this._onFrame);
+    }
+
+    stop(): void {
+        this.isTracking = false;
+        if (this.xrSession && this.animationFrameHandle !== null) {
+            this.xrSession.cancelAnimationFrame(this.animationFrameHandle);
+        }
+        this.animationFrameHandle = null;
+        this.xrSession = null;
+        this.registeredIds.clear();
+        this.lastButtons.clear();
+        this.lastAnalogTime.clear();
+        this.lastPoses.clear();
+    }
+
+    private _onFrame(timestamp: number, frame: XRFrame): void {
+        if (!this.isTracking || !this.xrSession) return;
+        this.animationFrameHandle = this.xrSession.requestAnimationFrame(this._onFrame);
+
+        const refSpace = this.c3d.xrSessionManager?.referenceSpace;
+        if (!refSpace) return;
+
+        this._detectInputTypeChange(frame, refSpace);
+        this._processControllers(timestamp, frame, refSpace);
+        this._processHands(frame, refSpace);
+    }
+
+    private _detectInputTypeChange(frame: XRFrame, refSpace: XRReferenceSpace): void {
+        if (!this.xrSession) return;
+
+        let sawController = false;
+        let sawHand = false;
+
+        for (const src of this.xrSession.inputSources) {
+            if (src.hand && this._getWristPose(frame, src, refSpace)) {
+                sawHand = true;
+            } else if (src.gripSpace && frame.getPose(src.gripSpace, refSpace)) {
+                sawController = true;
+            }
+        }
+
+        const current: 'none' | 'hand' | 'controller' = sawController ? 'controller' : sawHand ? 'hand' : 'none';
+        const prev = this.c3d.lastInputType;
+        if (current === prev) return;
+
+        this.c3d.customEvent.send('c3d.input.tracking.changed', [0, 0, 0], {
+            'Previously Tracking': prev,
+            'Now Tracking': current,
+        });
+        this.c3d.lastInputType = current;
+        this._updateEnabledStates(current);
+    }
+
+    private _updateEnabledStates(current: 'none' | 'hand' | 'controller'): void {
+        const pairs: Array<[string, 'controller' | 'hand']> = [
+            ['c3d_controller_left', 'controller'],
+            ['c3d_controller_right', 'controller'],
+            ['c3d_hand_left', 'hand'],
+            ['c3d_hand_right', 'hand'],
+        ];
+        for (const [id, type] of pairs) {
+            if (!this.registeredIds.has(id)) continue;
+            const pose = this.lastPoses.get(id) ?? { pos: [0, 0, 0], rot: [0, 0, 0, 1] };
+            this.c3d.dynamicObject.addInputSnapshot(id, pose.pos, pose.rot, null, [{ enabled: current === type }]);
+        }
+    }
+
+    private _processControllers(timestamp: number, frame: XRFrame, refSpace: XRReferenceSpace): void {
+        if (!this.xrSession) return;
+
+        for (const src of this.xrSession.inputSources) {
+            if (src.hand || src.targetRayMode !== 'tracked-pointer' || !src.gripSpace) continue;
+            const handedness = src.handedness as 'left' | 'right';
+            if (handedness !== 'left' && handedness !== 'right') continue;
+
+            const id = handedness === 'left' ? 'c3d_controller_left' : 'c3d_controller_right';
+
+            if (!this.registeredIds.has(id)) {
+                const profile = resolveControllerProfile(src.profiles);
+                if (!profile) continue;
+                const pose = frame.getPose(src.gripSpace, refSpace);
+                const pos = pose ? this._extractPos(pose) : [0, 0, 0];
+                const rot = pose ? this._extractRot(pose) : [0, 0, 0, 1];
+                const name = handedness === 'left' ? 'Left Controller' : 'Right Controller';
+                this.c3d.dynamicObject.registerControllerObject(
+                    name, profile.mesh(handedness), id, pos, rot,
+                    profile.controllerType(handedness), handedness
+                );
+                this.registeredIds.add(id);
+                this.lastPoses.set(id, { pos, rot });
+                continue;
+            }
+
+            const pose = frame.getPose(src.gripSpace, refSpace);
+            if (!pose) continue;
+            const pos = this._extractPos(pose);
+            const rot = this._extractRot(pose);
+            this.lastPoses.set(id, { pos, rot });
+
+            const buttons = this._readButtons(timestamp, id, src, handedness);
+            this.c3d.dynamicObject.addInputSnapshot(id, pos, rot, buttons ?? undefined);
+        }
+    }
+
+    private _readButtons(timestamp: number, id: string, src: XRInputSource, handedness: 'left' | 'right'): Record<string, ButtonState> | null {
+        const gp = src.gamepad;
+        if (!gp) return null;
+
+        const last = this.lastButtons.get(id) ?? {};
+        const lastAnalog = this.lastAnalogTime.get(id) ?? 0;
+        const emitAnalog = (timestamp - lastAnalog) >= ANALOG_THROTTLE_MS;
+        const changes: Record<string, ButtonState> = {};
+        let hasChanges = false;
+
+        // trigger (index 0, analog)
+        if (gp.buttons[0] && emitAnalog) {
+            const pct = Math.round(Math.min(1, Math.max(0, gp.buttons[0].value)) * 100);
+            if (!last['trigger'] || last['trigger'].buttonPercent !== pct) {
+                changes['trigger'] = { buttonPercent: pct };
+                hasChanges = true;
+            }
+        }
+
+        // grip (index 1, analog)
+        if (gp.buttons[1] && emitAnalog) {
+            const pct = Math.round(Math.min(1, Math.max(0, gp.buttons[1].value)) * 100);
+            if (!last['grip'] || last['grip'].buttonPercent !== pct) {
+                changes['grip'] = { buttonPercent: pct };
+                hasChanges = true;
+            }
+        }
+
+        // joystick (index 3 press + axes[2]/axes[3])
+        const axX = gp.axes[2] ?? 0;
+        const axY = gp.axes[3] ?? 0;
+        const joyPressed = gp.buttons[3]?.pressed ? 100 : 0;
+        const prevJoy = last['joystick'];
+        const axisMoved = emitAnalog && Math.sqrt(axX * axX + axY * axY) > JOYSTICK_MIN_MAGNITUDE &&
+            (Math.abs((prevJoy?.x ?? 0) - axX) > JOYSTICK_MIN_MAGNITUDE || Math.abs((prevJoy?.y ?? 0) - axY) > JOYSTICK_MIN_MAGNITUDE);
+        if (!prevJoy || prevJoy.buttonPercent !== joyPressed || axisMoved) {
+            changes['joystick'] = { buttonPercent: joyPressed, x: axX, y: axY };
+            hasChanges = true;
+        }
+
+        // primary button: A (right) / X (left) — index 4
+        if (gp.buttons[4]) {
+            const pct = gp.buttons[4].pressed ? 100 : 0;
+            const name = handedness === 'left' ? 'xbtn' : 'abtn';
+            if (!last[name] || last[name].buttonPercent !== pct) {
+                changes[name] = { buttonPercent: pct };
+                hasChanges = true;
+            }
+        }
+
+        // secondary button: B (right) / Y (left) — index 5
+        if (gp.buttons[5]) {
+            const pct = gp.buttons[5].pressed ? 100 : 0;
+            const name = handedness === 'left' ? 'ybtn' : 'bbtn';
+            if (!last[name] || last[name].buttonPercent !== pct) {
+                changes[name] = { buttonPercent: pct };
+                hasChanges = true;
+            }
+        }
+
+        if (!hasChanges) return null;
+        if (emitAnalog) this.lastAnalogTime.set(id, timestamp);
+        this.lastButtons.set(id, { ...last, ...changes });
+        return changes;
+    }
+
+    private _processHands(frame: XRFrame, refSpace: XRReferenceSpace): void {
+        if (typeof (frame as any).getJointPose !== 'function') return;
+        if (!this.xrSession) return;
+
+        for (const src of this.xrSession.inputSources) {
+            if (!src.hand) continue;
+            const handedness = src.handedness as 'left' | 'right';
+            if (handedness !== 'left' && handedness !== 'right') continue;
+
+            const id = handedness === 'left' ? 'c3d_hand_left' : 'c3d_hand_right';
+            const wristPose = this._getWristPose(frame, src, refSpace);
+            if (!wristPose) continue;
+
+            const pos = this._extractPos(wristPose);
+            const rot = this._extractRot(wristPose);
+            this.lastPoses.set(id, { pos, rot });
+
+            if (!this.registeredIds.has(id)) {
+                const meshname = handedness === 'left' ? 'handLeft' : 'handRight';
+                const ctType = handedness === 'left' ? 'hand_left' : 'hand_right';
+                const name = handedness === 'left' ? 'Left Hand' : 'Right Hand';
+                this.c3d.dynamicObject.registerControllerObject(name, meshname, id, pos, rot, ctType, handedness);
+                this.registeredIds.add(id);
+                continue;
+            }
+
+            this.c3d.dynamicObject.addInputSnapshot(id, pos, rot);
+        }
+    }
+
+    private _getWristPose(frame: XRFrame, src: XRInputSource, refSpace: XRReferenceSpace): XRPose | null {
+        if (!src.hand) return null;
+        const wristJoint = src.hand.get('wrist');
+        if (!wristJoint) return null;
+        try {
+            return (frame as any).getJointPose(wristJoint, refSpace) ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    private _extractPos(pose: XRPose): number[] {
+        const p = pose.transform.position;
+        return [p.x, p.y, p.z];
+    }
+
+    private _extractRot(pose: XRPose): number[] {
+        const o = pose.transform.orientation;
+        return [o.x, o.y, o.z, o.w];
+    }
+}
+
+export default ControllerInputTracker;

--- a/src/utils/ControllerInputTracker.ts
+++ b/src/utils/ControllerInputTracker.ts
@@ -326,12 +326,12 @@ class ControllerInputTracker {
 
     private _extractPos(pose: XRPose): number[] {
         const p = pose.transform.position;
-        return [p.x, p.y, p.z];
+        return [p.x, p.y, -p.z];
     }
 
     private _extractRot(pose: XRPose): number[] {
         const o = pose.transform.orientation;
-        return [o.x, o.y, o.z, o.w];
+        return [o.x, o.y, -o.z, -o.w];
     }
 }
 

--- a/src/utils/ControllerInputTracker.ts
+++ b/src/utils/ControllerInputTracker.ts
@@ -79,14 +79,27 @@ const CONTROLLER_PROFILE_MAP: Record<string, ControllerProfile> = {
     },
 };
 
-function resolveControllerProfile(profiles: readonly string[]): ControllerProfile | null {
+const UNKNOWN_PROFILE: ControllerProfile = {
+    mesh: _ => 'GenericController',
+    controllerType: h => h === 'left' ? 'unknown_controller_left' : 'unknown_controller_right',
+};
+
+function resolveControllerProfile(profiles: readonly string[], fallback?: string): ControllerProfile {
     for (const profile of profiles) {
         const lower = profile.toLowerCase();
         for (const key of Object.keys(CONTROLLER_PROFILE_MAP)) {
             if (lower.includes(key)) return CONTROLLER_PROFILE_MAP[key];
         }
     }
-    return null;
+    if (fallback) {
+        const fallbackProfile = CONTROLLER_PROFILE_MAP[fallback];
+        if (fallbackProfile) {
+            console.warn(`C3D: Unrecognized controller profiles [${profiles.join(', ')}]. Using configured fallback '${fallback}'.`);
+            return fallbackProfile;
+        }
+    }
+    console.warn(`C3D: Unrecognized controller profiles [${profiles.join(', ')}]. Using generic unknown controller.`);
+    return UNKNOWN_PROFILE;
 }
 
 const ANALOG_THROTTLE_MS = 100;
@@ -94,6 +107,7 @@ const JOYSTICK_MIN_MAGNITUDE = 0.05;
 
 class ControllerInputTracker {
     private c3d: C3DInstance;
+    private fallbackController?: string;
     private xrSession: XRSession | null = null;
     private isTracking = false;
     private animationFrameHandle: number | null = null;
@@ -103,8 +117,9 @@ class ControllerInputTracker {
     private lastAnalogTime = new Map<string, number>();
     private lastPoses = new Map<string, { pos: number[]; rot: number[] }>();
 
-    constructor(c3dInstance: C3DInstance) {
+    constructor(c3dInstance: C3DInstance, fallbackController?: string) {
         this.c3d = c3dInstance;
+        this.fallbackController = fallbackController;
         this._onFrame = this._onFrame.bind(this);
     }
 
@@ -191,8 +206,7 @@ class ControllerInputTracker {
             const id = handedness === 'left' ? 'c3d_controller_left' : 'c3d_controller_right';
 
             if (!this.registeredIds.has(id)) {
-                const profile = resolveControllerProfile(src.profiles);
-                if (!profile) continue;
+                const profile = resolveControllerProfile(src.profiles, this.fallbackController);
                 const pose = frame.getPose(src.gripSpace, refSpace);
                 const pos = pose ? this._extractPos(pose) : [0, 0, 0];
                 const rot = pose ? this._extractRot(pose) : [0, 0, 0, 1];


### PR DESCRIPTION
**Title:** feat: Controller/hand input tracking and deterministic UUIDs

**Overview**
This PR improves XR input tracking by registering controllers and hands as dynamic objects with per-frame polling. It also introduces deterministic UUIDs to enable out-of-the-box cross-session analytics. 

**Key Changes**

**XR Input Tracking**
* Registers left/right controllers and hands as dynamic objects, including `controllerType`, properties, and per-frame button snapshots.
* Replaces event-driven input detection with per-frame polling to reliably catch Quest controller ↔ hand swaps.
* Adds a fallback profile for unrecognized WebXR controllers.

**Deterministic Object IDs**
* Updates `registerObject()` to generate IDs using `uuidv5(sceneId::name::meshname, namespace)` instead of `uuidv4()`.
* Logical objects now receive identical IDs across sessions, allowing cross-session behavioral analytics without requiring developers to supply custom IDs.

**Tooling/ Developer**
* Automates `.env` loading for Jest via `dotenv`.
* Adds `claude.md`.