### PR TITLE
Fixed sync fast-path in startSession when deviceIdPromise is null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,10 +176,12 @@ class C3D {
     }
   }
 
-  async startSession(xrSession: XRSession | null = null): Promise<boolean> { 
+  async startSession(xrSession: XRSession | null = null): Promise<boolean> {
     if (this.core.isSessionActive) { return false; }
 
-    await this.waitForDeviceId();
+    if (this.deviceIdPromise) {
+      await this.waitForDeviceId();
+    }
   
     if (this.renderer) { 
       this.profiler.start(this.renderer);


### PR DESCRIPTION
Tests call startSession() without await and expect isSessionActive synchronously. The unconditional await waitForDeviceId() broke that by yielding a microtask even when deviceIdPromise was null.