### PR TITLE
WebXR SDK 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ c3d-sdk-webxr/
 
 The SDK is flexible and integrates seamlessly with various frameworks/ web engines such as **ThreeJS, Wonderland Engine, PlayCanvas, and more**.
 
+It supports both **immersive VR** and **immersive AR** WebXR sessions, including mobile AR flows built on Three.js and Mattercraft. For immersive AR sessions, the SDK automatically prefers a `local` reference space and falls back to `local-floor` when needed, while boundary tracking stays disabled unless the platform exposes a bounded reference space.
+
 It supports a wide range of development environments by providing multiple module formats in the /lib folder:
 
 * **UMD**: Universal format for direct use in browsers via a <script> tag.

--- a/__tests__/engine-gaze-interval-test.js
+++ b/__tests__/engine-gaze-interval-test.js
@@ -1,0 +1,278 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('three', () => {
+    class Vector2 {
+        constructor(x = 0, y = 0) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    class Vector3 {
+        constructor(x = 0, y = 0, z = 0) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        set(x, y, z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            return this;
+        }
+
+        transformDirection() {
+            return this;
+        }
+
+        clone() {
+            return new Vector3(this.x, this.y, this.z);
+        }
+
+        copy(other) {
+            this.x = other.x;
+            this.y = other.y;
+            this.z = other.z;
+            return this;
+        }
+
+        add(other) {
+            this.x += other.x;
+            this.y += other.y;
+            this.z += other.z;
+            return this;
+        }
+
+        addScaledVector(other, scalar) {
+            this.x += other.x * scalar;
+            this.y += other.y * scalar;
+            this.z += other.z * scalar;
+            return this;
+        }
+
+        sub(other) {
+            this.x -= other.x;
+            this.y -= other.y;
+            this.z -= other.z;
+            return this;
+        }
+
+        applyQuaternion() {
+            return this;
+        }
+
+        normalize() {
+            return this;
+        }
+    }
+
+    class Quaternion {
+        constructor(x = 0, y = 0, z = 0, w = 1) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        set(x, y, z, w) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+            return this;
+        }
+
+        copy(other) {
+            this.x = other.x;
+            this.y = other.y;
+            this.z = other.z;
+            this.w = other.w;
+            return this;
+        }
+
+        invert() {
+            return this;
+        }
+
+        premultiply() {
+            return this;
+        }
+    }
+
+    class Object3D {}
+
+    return {
+        REVISION: 'test',
+        Vector2,
+        Vector3,
+        Quaternion,
+        Object3D,
+        Raycaster: class {
+            constructor() {
+                this.ray = {
+                    origin: new Vector3(0, 1, 2),
+                    direction: new Vector3(0.25, -0.5, 0.75),
+                };
+            }
+
+            setFromCamera() {
+                this.ray.origin.set(0, 1, 2);
+                this.ray.direction.set(0.25, -0.5, 0.75);
+            }
+
+            intersectObjects() {
+                return [];
+            }
+        },
+        WebXRManager: class {},
+    };
+}, { virtual: true });
+
+jest.mock('three/examples/jsm/exporters/GLTFExporter.js', () => ({
+    GLTFExporter: class {},
+}), { virtual: true });
+
+jest.mock('jszip', () => class JSZipMock {}, { virtual: true });
+
+import ThreeAdapter from '../lib/cjs/adapters/threejs-adapter.cjs.js';
+
+describe('Three.js engine gaze interval', () => {
+    const createCameraStub = () => ({
+        matrixWorld: {},
+        updateWorldMatrix: jest.fn(),
+        getWorldPosition: jest.fn((target) => {
+            target.x = 0;
+            target.y = 1;
+            target.z = 2;
+            return target;
+        }),
+        getWorldQuaternion: jest.fn((target) => {
+            target.x = 0;
+            target.y = 0;
+            target.z = 0;
+            target.w = 1;
+            return target;
+        }),
+    });
+
+    const createC3DStub = () => ({
+        setDeviceProperty: jest.fn(),
+        core: {
+            config: {
+                GazeInterval: 0.1,
+            },
+        },
+        gaze: {
+            recordGaze: jest.fn(),
+        },
+        gazeRaycaster: null,
+    });
+
+    // Identity-transform origin stub. decompose() is a no-op so the internal
+    // temps stay at their zero/identity defaults, leaving poses unchanged.
+    const createAnalyticsOriginStub = () => ({
+        updateWorldMatrix: jest.fn(),
+        matrixWorld: { decompose: jest.fn() },
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('records every 60 Hz frame and emits a synthetic forward endpoint when nothing is hit', () => {
+        const c3d = createC3DStub();
+        const adapter = new ThreeAdapter(c3d);
+        adapter._camera = createCameraStub();
+        adapter._analyticsOrigin = createAnalyticsOriginStub();
+        adapter._lastGazeTime = Number.NEGATIVE_INFINITY;
+
+        // Five 60 Hz render frames — at the 16.66 ms cap every frame should
+        // produce a sample, which is what mobile AR replay needs to look
+        // smooth.
+        const timestamps = [0, 17, 34, 51, 68];
+        let timestampIndex = 0;
+        jest.spyOn(performance, 'now').mockImplementation(() => timestamps[timestampIndex++]);
+
+        for (let i = 0; i < timestamps.length; i++) {
+            adapter._recordEngineGaze();
+        }
+
+        expect(c3d.gaze.recordGaze).toHaveBeenCalledTimes(5);
+        expect(c3d.gaze.recordGaze.mock.calls[0][0]).toEqual([0, 1, -2]);
+        expect(c3d.gaze.recordGaze.mock.calls[0][1]).toEqual([0, 0, -0, -1]);
+        // Every sample carries a `g` payload — a synthetic world-space
+        // endpoint along the camera forward when there is no real hit. This
+        // keeps the dashboard's beam base locked to the current head pose
+        // between actual object hits.
+        expect(c3d.gaze.recordGaze.mock.calls[0]).toHaveLength(3);
+        const fallback = c3d.gaze.recordGaze.mock.calls[0][2];
+        expect(fallback.objectId).toBe('');
+        expect(Array.isArray(fallback.point)).toBe(true);
+        expect(fallback.point).toHaveLength(3);
+        // Mock camera world position is (0,1,2) and forward stays (0,0,-1)
+        // through the stub's transformDirection, so endpoint = (0,1,2) + 2*(0,0,-1)
+        // = (0,1,0), Z-flipped to (0,1,-0) (i.e. 0).
+        expect(fallback.point[0]).toBeCloseTo(0);
+        expect(fallback.point[1]).toBeCloseTo(1);
+        expect(fallback.point[2]).toBeCloseTo(0);
+    });
+
+    test('still throttles below the 60 Hz cap when frames arrive faster', () => {
+        const c3d = createC3DStub();
+        const adapter = new ThreeAdapter(c3d);
+        adapter._camera = createCameraStub();
+        adapter._analyticsOrigin = createAnalyticsOriginStub();
+        adapter._lastGazeTime = Number.NEGATIVE_INFINITY;
+
+        // 120 Hz-style timing: 8 ms per frame. Only every other frame should
+        // pass the 16.66 ms gate.
+        const timestamps = [0, 8, 16, 24, 32, 40, 48];
+        let timestampIndex = 0;
+        jest.spyOn(performance, 'now').mockImplementation(() => timestamps[timestampIndex++]);
+
+        for (let i = 0; i < timestamps.length; i++) {
+            adapter._recordEngineGaze();
+        }
+
+        // Records at t=0, t=24 (24 > 16.66 from 0), t=48 (48-24=24 > 16.66).
+        expect(c3d.gaze.recordGaze).toHaveBeenCalledTimes(3);
+    });
+
+    test('uses configured interval without the 60 Hz cap when no analytics origin is set', () => {
+        const c3d = createC3DStub(); // GazeInterval: 0.1 → 100 ms
+        const adapter = new ThreeAdapter(c3d);
+        adapter._camera = createCameraStub();
+        // No _analyticsOrigin — simulates a standard WebXR/VR session.
+        adapter._lastGazeTime = Number.NEGATIVE_INFINITY;
+
+        // Six frames spread over ~83 ms — well under the 100 ms configured
+        // interval. Only the very first frame should produce a sample.
+        const timestamps = [0, 17, 34, 51, 68, 85];
+        let timestampIndex = 0;
+        jest.spyOn(performance, 'now').mockImplementation(() => timestamps[timestampIndex++]);
+
+        for (let i = 0; i < timestamps.length; i++) {
+            adapter._recordEngineGaze();
+        }
+
+        expect(c3d.gaze.recordGaze).toHaveBeenCalledTimes(1);
+    });
+
+    test('passes null gaze payload on no-hit frames when no analytics origin is set', () => {
+        const c3d = createC3DStub();
+        const adapter = new ThreeAdapter(c3d);
+        adapter._camera = createCameraStub();
+        // No _analyticsOrigin — synthetic fallback should NOT activate.
+        adapter._lastGazeTime = Number.NEGATIVE_INFINITY;
+
+        jest.spyOn(performance, 'now').mockReturnValue(0);
+        adapter._recordEngineGaze();
+
+        expect(c3d.gaze.recordGaze).toHaveBeenCalledTimes(1);
+        // Third argument should be null — preserves pre-WebAR behaviour.
+        expect(c3d.gaze.recordGaze.mock.calls[0][2]).toBeNull();
+    });
+});

--- a/__tests__/mobile-ar-session-test.js
+++ b/__tests__/mobile-ar-session-test.js
@@ -1,0 +1,140 @@
+import C3DAnalytics from '../lib/cjs/index.cjs.js';
+
+const settings = {
+    config: {
+        APIKey: 'test-api-key',
+        networkHost: 'data.cognitive3d.com',
+        allSceneData: [
+            {
+                sceneName: 'BasicScene',
+                sceneId: '93f486e4-0e22-4650-946a-e64ce527f915',
+                versionNumber: '1',
+            },
+        ],
+    },
+};
+
+const scene1 = settings.config.allSceneData[0].sceneName;
+
+function createXRSessionMock({ mode, supportedSpaces, inputSources = [] }) {
+    return {
+        mode,
+        inputSources,
+        requestReferenceSpace: jest.fn((type) => {
+            if (supportedSpaces[type]) {
+                return Promise.resolve(supportedSpaces[type]);
+            }
+            return Promise.reject(new Error(`Unsupported reference space: ${type}`));
+        }),
+        requestAnimationFrame: jest.fn(() => 1),
+        cancelAnimationFrame: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    };
+}
+
+let c3d;
+
+beforeEach(async () => {
+    c3d = new C3DAnalytics(settings);
+    c3d.setScene(scene1);
+    c3d.core.resetNewUserDeviceProperties();
+    c3d.sendData = jest.fn().mockResolvedValue(200);
+
+    if (c3d.isSessionActive()) {
+        await expect(c3d.endSession()).resolves.toEqual(200);
+    }
+});
+
+test('Prefer local reference space for immersive-ar sessions and disable VR-only flags', async () => {
+    const xrSession = createXRSessionMock({
+        mode: 'immersive-ar',
+        supportedSpaces: {
+            local: { kind: 'local' },
+        },
+    });
+
+    await expect(c3d.startSession(xrSession)).resolves.toBe(true);
+
+    expect(xrSession.requestReferenceSpace.mock.calls.map(([type]) => type)).toEqual(['local']);
+    expect(c3d.getXRSessionMode()).toEqual('immersive-ar');
+    expect(c3d.getXRReferenceSpaceType()).toEqual('local');
+    expect(c3d.isARSession()).toBe(true);
+    expect(c3d.isVRSession()).toBe(false);
+    expect(c3d.core.sessionProperties['c3d.session.xr.mode']).toEqual('immersive-ar');
+    expect(c3d.core.sessionProperties['c3d.session.xr.reference_space']).toEqual('local');
+    expect(c3d.core.sessionProperties['c3d.session.xr.boundary_available']).toBe(false);
+    expect(c3d.core.sessionProperties['c3d.device.controllerinputs.enabled']).toBe(false);
+
+    await expect(c3d.endSession()).resolves.toEqual(200);
+});
+
+test('Keep local-floor and tracked controller behavior for immersive-vr sessions', async () => {
+    const xrSession = createXRSessionMock({
+        mode: 'immersive-vr',
+        supportedSpaces: {
+            'local-floor': { kind: 'local-floor' },
+            'bounded-floor': { kind: 'bounded-floor', boundsGeometry: [] },
+        },
+        inputSources: [
+            {
+                handedness: 'right',
+                targetRayMode: 'tracked-pointer',
+                gripSpace: { kind: 'controller-grip' },
+                profiles: ['oculus-touch-v3'],
+            },
+        ],
+    });
+
+    await expect(c3d.startSession(xrSession)).resolves.toBe(true);
+
+    expect(xrSession.requestReferenceSpace.mock.calls.map(([type]) => type)).toEqual(['local-floor', 'bounded-floor']);
+    expect(c3d.getXRSessionMode()).toEqual('immersive-vr');
+    expect(c3d.getXRReferenceSpaceType()).toEqual('local-floor');
+    expect(c3d.isARSession()).toBe(false);
+    expect(c3d.isVRSession()).toBe(true);
+    expect(c3d.core.sessionProperties['c3d.session.xr.mode']).toEqual('immersive-vr');
+    expect(c3d.core.sessionProperties['c3d.session.xr.reference_space']).toEqual('local-floor');
+    expect(c3d.core.sessionProperties['c3d.session.xr.boundary_available']).toBe(true);
+    expect(c3d.core.sessionProperties['c3d.device.controllerinputs.enabled']).toBe(true);
+    expect(c3d.getDeviceProperties()['c3d.device.hmd.type']).toEqual('Quest 2');
+
+    await expect(c3d.endSession()).resolves.toEqual(200);
+});
+
+test('Allow gaze raycasting to be attached after session start for mobile AR integrations', async () => {
+    const xrSession = createXRSessionMock({
+        mode: 'immersive-ar',
+        supportedSpaces: {
+            local: { kind: 'local' },
+        },
+    });
+
+    await expect(c3d.startSession(xrSession)).resolves.toBe(true);
+
+    const lateBoundRaycaster = jest.fn(() => ({
+        objectId: 'late-bound-object',
+        point: [1, 2, 3],
+    }));
+    const gazeSpy = jest.spyOn(c3d.gaze, 'recordGaze');
+
+    c3d.gazeRaycaster = lateBoundRaycaster;
+
+    c3d.xrSessionManager.onXRFrame(200, {
+        getViewerPose: jest.fn(() => ({
+            transform: {
+                position: { x: 4, y: 5, z: 6 },
+                orientation: { x: 0, y: 0, z: 0, w: 1 },
+            },
+        })),
+    });
+
+    expect(lateBoundRaycaster).toHaveBeenCalledTimes(1);
+    expect(gazeSpy).toHaveBeenCalledTimes(1);
+    expect(gazeSpy.mock.calls[0][2]).toEqual({
+        objectId: 'late-bound-object',
+        point: [1, 2, 3],
+    });
+
+    await expect(c3d.endSession()).resolves.toEqual(200);
+});

--- a/__tests__/mobile-ar-session-test.js
+++ b/__tests__/mobile-ar-session-test.js
@@ -16,15 +16,19 @@ const settings = {
 
 const scene1 = settings.config.allSceneData[0].sceneName;
 
-function createXRSessionMock({ mode, supportedSpaces, inputSources = [] }) {
-    const spaceMap = new Map(Object.entries(supportedSpaces));
+function createXRSessionMock({ mode, localSpace, localFloorSpace, boundedFloorSpace, inputSources = [] }) {
     return {
         mode,
         inputSources,
         requestReferenceSpace: jest.fn((type) => {
-            const space = spaceMap.get(type);
-            if (space) {
-                return Promise.resolve(space);
+            if (type === 'local' && localSpace) {
+                return Promise.resolve(localSpace);
+            }
+            if (type === 'local-floor' && localFloorSpace) {
+                return Promise.resolve(localFloorSpace);
+            }
+            if (type === 'bounded-floor' && boundedFloorSpace) {
+                return Promise.resolve(boundedFloorSpace);
             }
             return Promise.reject(new Error(`Unsupported reference space: ${type}`));
         }),
@@ -51,9 +55,7 @@ beforeEach(async () => {
 test('Prefer local reference space for immersive-ar sessions and disable VR-only flags', async () => {
     const xrSession = createXRSessionMock({
         mode: 'immersive-ar',
-        supportedSpaces: {
-            local: { kind: 'local' },
-        },
+        localSpace: { kind: 'local' },
     });
 
     await expect(c3d.startSession(xrSession)).resolves.toBe(true);
@@ -74,10 +76,8 @@ test('Prefer local reference space for immersive-ar sessions and disable VR-only
 test('Keep local-floor and tracked controller behavior for immersive-vr sessions', async () => {
     const xrSession = createXRSessionMock({
         mode: 'immersive-vr',
-        supportedSpaces: {
-            'local-floor': { kind: 'local-floor' },
-            'bounded-floor': { kind: 'bounded-floor', boundsGeometry: [] },
-        },
+        localFloorSpace: { kind: 'local-floor' },
+        boundedFloorSpace: { kind: 'bounded-floor', boundsGeometry: [] },
         inputSources: [
             {
                 handedness: 'right',
@@ -107,9 +107,7 @@ test('Keep local-floor and tracked controller behavior for immersive-vr sessions
 test('Allow gaze raycasting to be attached after session start for mobile AR integrations', async () => {
     const xrSession = createXRSessionMock({
         mode: 'immersive-ar',
-        supportedSpaces: {
-            local: { kind: 'local' },
-        },
+        localSpace: { kind: 'local' },
     });
 
     await expect(c3d.startSession(xrSession)).resolves.toBe(true);

--- a/__tests__/mobile-ar-session-test.js
+++ b/__tests__/mobile-ar-session-test.js
@@ -17,12 +17,14 @@ const settings = {
 const scene1 = settings.config.allSceneData[0].sceneName;
 
 function createXRSessionMock({ mode, supportedSpaces, inputSources = [] }) {
+    const spaceMap = new Map(Object.entries(supportedSpaces));
     return {
         mode,
         inputSources,
         requestReferenceSpace: jest.fn((type) => {
-            if (supportedSpaces[type]) {
-                return Promise.resolve(supportedSpaces[type]);
+            const space = spaceMap.get(type);
+            if (space) {
+                return Promise.resolve(space);
             }
             return Promise.reject(new Error(`Unsupported reference space: ${type}`));
         }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognitive3d/analytics",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "This SDK allows you to integrate your Javascript Applications with Cognitive3D, which provides analytics and insights about your VR/AR/MR project.",
   "main": "lib/cjs/index.cjs.js",
   "module": "lib/esm/index.esm.js",

--- a/src/adapters/threejs-adapter.ts
+++ b/src/adapters/threejs-adapter.ts
@@ -16,6 +16,7 @@ interface DynamicObjectOptions {
     positionThreshold?: number;
     rotationThreshold?: number;
     scaleThreshold?: number;
+    useLocalScale?: boolean;
 }
 
 // Helper interface for extended WebXRManager
@@ -34,16 +35,63 @@ class C3DThreeAdapter {
     // Used to avoid TS errors in environments without FileSystem API types
     private exportDirHandle: any = null; 
     private _interactableObjects: THREE.Object3D[] = [];  
+    private _trackedRootByInteractable = new Map<string, THREE.Object3D>();
 
     // Properties for engine-camera driven gaze tracking
     private _camera: THREE.Camera | null = null;
     private _lastGazeTime: number = 0;
+    private _defaultGazeRaycaster: (() => GazeHitData | null) | null = null;
+
+    // Optional analytics origin. When set, all camera and dynamic-object poses
+    // are recorded relative to this object's world transform instead of raw
+    // world coordinates. Used by Mattercraft WebAR so the scene root translation
+    // (and any other ancestor transforms outside the Zappar anchor frame) do
+    // not contaminate the recorded gaze/object positions.
+    private _analyticsOrigin: THREE.Object3D | null = null;
 
     // Object Pooling for GC optimization
     private _tempVec = new THREE.Vector3();
     private _tempQuat = new THREE.Quaternion();
     private _tempScale = new THREE.Vector3();
-    private _tempForward = new THREE.Vector3(0, 0, -1); // Forward vector 
+    private _tempForward = new THREE.Vector3(0, 0, -1); // Forward vector
+    private _gazeRaycaster = new THREE.Raycaster();
+    private _gazeOriginNDC = new THREE.Vector2(0, 0);
+
+    // Temps used only by the analytics-origin transform path. Kept separate
+    // from the gaze/object temps so concurrent reads in the same frame don't
+    // clobber each other.
+    private _originPosTemp = new THREE.Vector3();
+    private _originQuatTemp = new THREE.Quaternion();
+    private _originScaleTemp = new THREE.Vector3();
+    private _originInverseQuatTemp = new THREE.Quaternion();
+
+    // Synthetic-gaze fallback temps. On no-hit frames we emit a world-space
+    // point a fixed distance ahead of the camera so the dashboard's beam
+    // always has an endpoint anchored to the current head pose, instead of
+    // sticking to the last real hit's pose while the head icon keeps moving.
+    private _fallbackEndpointTemp = new THREE.Vector3();
+    private _fallbackForwardTemp = new THREE.Vector3();
+    private _fallbackQuatTemp = new THREE.Quaternion();
+    // Distance in meters from camera to the synthetic gaze endpoint after the
+    // last-hit grace window elapses. Tuned for AR-scale scenes (typical user
+    // viewing distance is ~1 m).
+    private static readonly FALLBACK_GAZE_DISTANCE = 2;
+
+    // Last-hit cache. During a heavy jitter or fast camera motion the
+    // raycaster can produce isolated misses while the user is still
+    // effectively aiming at the same object — without this cache the beam
+    // endpoint would flick out to the forward-synthetic point and snap back
+    // on the very next frame. Re-anchoring to the last real hit's world
+    // position for a short grace window keeps the beam visually stable
+    // through those misses.
+    private _hasLastHit = false;
+    private _lastHitWorldPoint = new THREE.Vector3();
+    private _lastHitTimestamp = 0;
+    // Grace window after a real hit during which transient misses reuse the
+    // cached world point. ~12 frames at 60 Hz — long enough to span typical
+    // tracking-noise miss bursts, short enough that genuinely looking away
+    // transitions to forward-synthetic without a perceptible lag.
+    private static readonly LAST_HIT_GRACE_MS = 200;
 
     // Helper to log object hierarchy recursively for during object export debugging 
     private _logHierarchy(obj: THREE.Object3D, depth = 0): void {
@@ -73,22 +121,157 @@ class C3DThreeAdapter {
         return [quat.x, quat.y, quat.z, quat.w];
     }
 
+    private _toAnalyticsDirection(direction: THREE.Vector3): number[] {
+        return [direction.x, direction.y, -direction.z];
+    }
+
+    private _getAnalyticsForwardDirection(camera: THREE.Camera): number[] {
+        camera.updateWorldMatrix(true, false);
+        this._tempForward.set(0, 0, -1).transformDirection(camera.matrixWorld);
+        return this._toAnalyticsDirection(this._tempForward);
+    }
+
+    private _getEngineGazeIntervalMs(): number {
+        const configuredInterval = this.c3d.core.config.GazeInterval;
+        const configuredIntervalMs = typeof configuredInterval === 'number' && configuredInterval > 0
+            ? configuredInterval * 1000
+            : 100;
+
+        // Cap at 60 Hz only for WebAR (analytics origin set). Handheld AR at
+        // 30 Hz shows visible stair-stepping in lateral motion replay because
+        // the 60 Hz display has no fresh sample every other frame. WebXR/VR
+        // sessions can be long and don't need the extra sample density.
+        if (this._analyticsOrigin) {
+            return Math.min(configuredIntervalMs, 1000 / 60);
+        }
+        return configuredIntervalMs;
+    }
+
+    private _getCenterRayHit(camera: THREE.Camera): GazeHitData | null {
+        camera.updateWorldMatrix(true, false);
+        this._gazeRaycaster.setFromCamera(this._gazeOriginNDC, camera);
+        if (this._interactableObjects.length === 0) {
+            return null;
+        }
+
+        const intersects = this._gazeRaycaster.intersectObjects(this._interactableObjects, true);
+        if (intersects.length === 0) {
+            return null;
+        }
+
+        const intersection = intersects[0];
+        const trackedRoot = this._resolveTrackedRoot(intersection.object);
+        if (!trackedRoot || !trackedRoot.userData?.c3dId) {
+            return null;
+        }
+
+        // Cache the world-space hit point for the synthetic-gaze fallback so
+        // that transient raycast misses during heavy jitter keep the beam
+        // endpoint pinned to the same world location instead of snapping out
+        // to a forward-synthetic point.
+        this._lastHitWorldPoint.copy(intersection.point);
+        this._lastHitTimestamp = performance.now();
+        this._hasLastHit = true;
+
+        const worldPoint = intersection.point.clone();
+        trackedRoot.worldToLocal(worldPoint);
+        worldPoint.z *= -1;
+
+        return {
+            objectId: trackedRoot.userData.c3dId,
+            point: [worldPoint.x, worldPoint.y, worldPoint.z]
+        };
+    }
+
+    private _resolveTrackedRoot(hitObject: THREE.Object3D | null): THREE.Object3D | null {
+        let current: THREE.Object3D | null = hitObject;
+
+        while (current) {
+            if (current.userData?.c3dTrackedRoot instanceof THREE.Object3D) {
+                return current.userData.c3dTrackedRoot;
+            }
+
+            const mappedRoot = this._trackedRootByInteractable.get(current.uuid);
+            if (mappedRoot) {
+                return mappedRoot;
+            }
+
+            if (current.userData?.c3dId) {
+                return current;
+            }
+
+            current = current.parent;
+        }
+
+        return null;
+    }
+
     public recordGazeFromCamera(camera: THREE.Camera): void {
         const worldPos = this._tempVec;
         const worldQuat = this._tempQuat;
         camera.getWorldPosition(worldPos);
         camera.getWorldQuaternion(worldQuat);
 
+        this._applyAnalyticsOriginTransform(worldPos, worldQuat);
+
         // Apply C3D Coordinate Corrections
         const correctedPosition = [worldPos.x, worldPos.y, -worldPos.z];
         const correctedOrientation = [worldQuat.x, worldQuat.y, -worldQuat.z, -worldQuat.w];
 
         // Calculate gaze vector natively using pooled forward vector
-        const forward = this._tempForward.set(0, 0, -1).applyQuaternion(worldQuat);
-        // Gaze direction also needs the Z flipped
-        const correctedGaze = [forward.x, forward.y, -forward.z];
+        const correctedGaze = this._getAnalyticsForwardDirection(camera);
 
         this.c3d.gaze.recordGaze(correctedPosition, correctedOrientation, correctedGaze);
+    }
+
+    /**
+     * Set the analytics origin. When non-null, camera and dynamic-object poses
+     * are recorded in this origin's local frame instead of world space. Pass
+     * null to clear and revert to raw world-space recording.
+     *
+     * In Mattercraft WebAR the natural origin is the scene's top-level Group
+     * (or the active Zappar anchor), so the scene-root translation does not
+     * appear as a constant offset in the recorded camera path.
+     */
+    public setAnalyticsOrigin(origin: THREE.Object3D | null): void {
+        this._analyticsOrigin = origin;
+    }
+
+    public getAnalyticsOrigin(): THREE.Object3D | null {
+        return this._analyticsOrigin;
+    }
+
+    /**
+     * Transform a world-space pose into the analytics origin's local frame in-place.
+     * Mutates the supplied position and quaternion. No-op when no origin is set.
+     * Scale is intentionally ignored (assumes the origin has identity scale,
+     * which is the common case for scene roots).
+     */
+    private _applyAnalyticsOriginTransform(position: THREE.Vector3, quaternion: THREE.Quaternion): void {
+        if (!this._analyticsOrigin) return;
+
+        this._analyticsOrigin.updateWorldMatrix(true, false);
+        this._analyticsOrigin.matrixWorld.decompose(
+            this._originPosTemp,
+            this._originQuatTemp,
+            this._originScaleTemp
+        );
+
+        this._originInverseQuatTemp.copy(this._originQuatTemp).invert();
+
+        // Translate then rotate into origin-local space
+        position.sub(this._originPosTemp).applyQuaternion(this._originInverseQuatTemp);
+        quaternion.premultiply(this._originInverseQuatTemp);
+    }
+
+    /**
+     * Public version of the analytics-origin transform helper. Lets the
+     * Mattercraft integration record one-shot snapshots (e.g. dynamic object
+     * initial registration) using the same coordinate frame as the per-frame
+     * pose stream.
+     */
+    public transformWorldToAnalyticsOrigin(position: THREE.Vector3, quaternion: THREE.Quaternion): void {
+        this._applyAnalyticsOriginTransform(position, quaternion);
     }
     
     //  Helper function for recursively finding dynamic interactable objects in a three.scene or three.group
@@ -133,9 +316,20 @@ class C3DThreeAdapter {
         }
 
         this._camera = camera; 
+        this._gazeRaycaster.far = 1000;
 
         // Setup Dynamic Objects & Gaze, Clear previous list
         this._interactableObjects = [];
+        this._trackedRootByInteractable.clear();
+        if (this.c3d.gazeRaycaster === this._defaultGazeRaycaster) {
+            this.c3d.gazeRaycaster = null;
+        }
+        this._defaultGazeRaycaster = null;
+
+        // Drop any cached hit state from a prior session so the fallback path
+        // never re-anchors a fresh session's beam to a stale world point.
+        this._hasLastHit = false;
+        this._lastHitTimestamp = 0;
 
         if (trackableTarget) {
             if (Array.isArray(trackableTarget)) {
@@ -225,50 +419,8 @@ class C3DThreeAdapter {
     }
 
     private _setupGazeRaycasting(camera: THREE.Camera): void {
-        const raycaster = new THREE.Raycaster();
-        raycaster.far = 1000;
-        
-        const gazeOriginNDC = new THREE.Vector2(0, 0);
-
-        this.c3d.gazeRaycaster = (): GazeHitData | null => {
-            raycaster.setFromCamera(gazeOriginNDC, camera);
-            
-            // Intersect against the cached array, NOT a specific group
-            const intersects = raycaster.intersectObjects(this._interactableObjects, true);
-
-            if (intersects.length > 0) {
-                const intersection = intersects[0];
-                let targetObject: THREE.Object3D | null = intersection.object;
-
-                // Traverse up from the hit mesh to find the actual 'tracked' parent (if applicable)
-                // This handles cases where we track a "Car" (Group) but hit the "Tire" (Mesh)
-                while (targetObject) {
-                    if (targetObject.userData && targetObject.userData.c3dId) {
-                        break;
-                    }
-                    // Stop if we hit the scene root or run out of parents
-                    if (!targetObject.parent) {
-                        targetObject = null;
-                        break;
-                    }
-                    targetObject = targetObject.parent;
-                }
-
-                if (targetObject && targetObject.userData.c3dId) {
-                    const worldPoint = intersection.point.clone();
-                    targetObject.worldToLocal(worldPoint);
-                    // Standardize coordinate system if necessary (often needed for analytics backends)
-                    worldPoint.x *= 1;
-                    worldPoint.z *= -1;
-
-                    return {
-                        objectId: targetObject.userData.c3dId,
-                        point: [worldPoint.x, worldPoint.y, worldPoint.z]
-                    };
-                }
-            }
-            return null;
-        };
+        this._defaultGazeRaycaster = (): GazeHitData | null => this._getCenterRayHit(camera);
+        this.c3d.gazeRaycaster = this._defaultGazeRaycaster;
     }
 
     // Handle Gaze tracking natively through Three.js camera
@@ -276,28 +428,95 @@ class C3DThreeAdapter {
         if (!this._camera) return;
 
         const now = performance.now();
-        // Read directly from the instantiated core config
-        const intervalMs = this.c3d.core.config.GazeInterval ? this.c3d.core.config.GazeInterval * 1000 : 100;
+        const intervalMs = this._getEngineGazeIntervalMs();
 
-        if (now - this._lastGazeTime >= intervalMs) {
-            this._lastGazeTime = now;
-
-            const worldPos = this._tempVec;
-            const worldQuat = this._tempQuat;
-            this._camera.getWorldPosition(worldPos);
-            this._camera.getWorldQuaternion(worldQuat);
-
-            // PERFECTLY MATCHES webxr.ts
-            const correctedPosition = [worldPos.x, worldPos.y, -worldPos.z];
-            const correctedOrientation = [worldQuat.x, worldQuat.y, -worldQuat.z, -worldQuat.w];
-
-            let gazeHitData: GazeHitData | null = null;
-            if (this.c3d.gazeRaycaster) {
-                gazeHitData = this.c3d.gazeRaycaster();
-            }
-
-            this.c3d.gaze.recordGaze(correctedPosition, correctedOrientation, gazeHitData);
+        if (now - this._lastGazeTime < intervalMs) {
+            return;
         }
+        this._lastGazeTime = now;
+
+        // 1. Resolve a possible real hit BEFORE the in-place origin transform,
+        //    so the raycaster still sees world-space camera/object transforms.
+        let gazePayload: GazeHitData | null = null;
+        if (this.c3d.gazeRaycaster) {
+            const hitPayload = this.c3d.gazeRaycaster === this._defaultGazeRaycaster
+                ? this._getCenterRayHit(this._camera)
+                : this.c3d.gazeRaycaster();
+            if (hitPayload) {
+                gazePayload = hitPayload;
+            }
+        }
+
+        // 2. On no-hit frames in WebAR (analytics origin set), synthesize a
+        //    world-space endpoint in front of the camera so every sample
+        //    carries a `g` payload — without it the dashboard's beam re-anchors
+        //    only on hit samples and visibly lags behind the head icon between
+        //    hits during handheld motion. WebXR/VR sessions don't exhibit the
+        //    same beam-lag pattern, so we preserve the original null-on-miss
+        //    behaviour there. `now` is forwarded so the grace-window check uses
+        //    the same timestamp as the throttle gate.
+        if (!gazePayload && this._analyticsOrigin) {
+            const fallbackPoint = this._computeFallbackGazePoint(this._camera, now);
+            gazePayload = { objectId: "", point: fallbackPoint };
+        }
+
+        // 3. Capture the head pose and re-express in analytics-origin frame.
+        const worldPos = this._tempVec;
+        const worldQuat = this._tempQuat;
+        this._camera.getWorldPosition(worldPos);
+        this._camera.getWorldQuaternion(worldQuat);
+        this._applyAnalyticsOriginTransform(worldPos, worldQuat);
+
+        const correctedPosition = [worldPos.x, worldPos.y, -worldPos.z];
+        const correctedOrientation = [worldQuat.x, worldQuat.y, -worldQuat.z, -worldQuat.w];
+
+        this.c3d.gaze.recordGaze(correctedPosition, correctedOrientation, gazePayload);
+    }
+
+    /**
+     * Build a world-space point to send as the fallback gaze endpoint for the
+     * dashboard, expressed in the analytics origin's frame with the standard
+     * C3D Z-flip applied.
+     *
+     * Two modes:
+     *   1. Recent real hit (within LAST_HIT_GRACE_MS) — re-use the cached
+     *      world hit point. Keeps the beam parked on the same world location
+     *      during transient raycast misses caused by tracking jitter.
+     *   2. No recent hit — synthesize a forward-looking point at
+     *      FALLBACK_GAZE_DISTANCE m in the camera's forward direction.
+     *
+     * The returned array has no `objectId` partner — it is intended to be sent
+     * as `{ objectId: "", point }`, which the SDK serializes as a `g` payload
+     * with no `o`, i.e. a world-space gaze endpoint. The dashboard treats
+     * world-space `g` as the beam's far endpoint, which keeps the beam base
+     * locked to the current head pose between actual object hits.
+     *
+     * `now` is supplied by the caller so the grace-window evaluation uses the
+     * same clock reading as the throttle gate — this also keeps the function
+     * free of side effects against performance.now(), which keeps the test
+     * timestamp mock deterministic.
+     */
+    private _computeFallbackGazePoint(camera: THREE.Camera, now: number): number[] {
+        const withinHitGrace = this._hasLastHit
+            && (now - this._lastHitTimestamp) <= C3DThreeAdapter.LAST_HIT_GRACE_MS;
+
+        if (withinHitGrace) {
+            this._fallbackEndpointTemp.copy(this._lastHitWorldPoint);
+        } else {
+            camera.getWorldPosition(this._fallbackEndpointTemp);
+            this._fallbackForwardTemp.set(0, 0, -1).transformDirection(camera.matrixWorld);
+            this._fallbackEndpointTemp.addScaledVector(
+                this._fallbackForwardTemp,
+                C3DThreeAdapter.FALLBACK_GAZE_DISTANCE
+            );
+        }
+
+        // Same origin transform as the head pose so beam endpoint and beam
+        // base live in the same coordinate frame in replay.
+        this._fallbackQuatTemp.set(0, 0, 0, 1);
+        this._applyAnalyticsOriginTransform(this._fallbackEndpointTemp, this._fallbackQuatTemp);
+
+        return [this._fallbackEndpointTemp.x, this._fallbackEndpointTemp.y, -this._fallbackEndpointTemp.z];
     }
 
     public trackDynamicObject(object: THREE.Object3D, id: string, options: DynamicObjectOptions): void {
@@ -317,7 +536,7 @@ class C3DThreeAdapter {
         dynamicObjectManager.trackedObjects.forEach((tracked, id) => {
             if (!tracked.lastPosition) return;
 
-            const { object, lastPosition, lastRotation, lastScale, positionThreshold, rotationThreshold, scaleThreshold } = tracked;
+            const { object, lastPosition, lastRotation, lastScale, positionThreshold, rotationThreshold, scaleThreshold, useLocalScale } = tracked;
             const threeObject = object as THREE.Object3D;
             const threeLastPos = lastPosition as THREE.Vector3;
             const threeLastRot = lastRotation as THREE.Quaternion;
@@ -325,6 +544,15 @@ class C3DThreeAdapter {
 
             threeObject.updateWorldMatrix(true, false);
             threeObject.matrixWorld.decompose(this._tempVec, this._tempQuat, this._tempScale);
+
+            // Re-express the tracked object's pose in the analytics origin's
+            // local frame so dynamic object positions stay consistent with the
+            // camera pose stream and the exported scene root.
+            this._applyAnalyticsOriginTransform(this._tempVec, this._tempQuat);
+
+            if (useLocalScale) {
+                this._tempScale.copy(threeObject.scale);
+            }
 
             const positionChanged = this._tempVec.distanceTo(threeLastPos) > (positionThreshold || 0.01);
             const rotationChanged = this._tempQuat.angleTo(threeLastRot) * (180 / Math.PI) > (rotationThreshold || 1);
@@ -345,10 +573,13 @@ class C3DThreeAdapter {
         });
     }
 
-    public addInteractable(object: THREE.Object3D): void {
+    public addInteractable(object: THREE.Object3D, trackedRoot: THREE.Object3D = object): void {
         if (!this._interactableObjects.includes(object)) {
             this._interactableObjects.push(object);
         }
+
+        this._trackedRootByInteractable.set(object.uuid, trackedRoot);
+        object.userData.c3dTrackedRoot = trackedRoot;
     }
 
     async _ensureExportDir(): Promise<any> {
@@ -388,9 +619,14 @@ class C3DThreeAdapter {
         }, 800);
     }
 
+    private _getExportFileStem(name: string): string {
+        return name.replace(/\.(glb|gltf|fbx|obj|usdz)$/i, '');
+    }
+
     public exportScene(scene: THREE.Scene, sceneName: string, renderer: THREE.WebGLRenderer, camera: THREE.Camera): void {
         const exporter = new GLTFExporter();
         const staticScene = scene.clone(true);
+        const exportDirPromise = this._ensureExportDir();
 
         staticScene.traverse((obj) => {
             if (obj.userData && (obj.userData.c3dId || obj.userData.isDynamic)) {
@@ -410,7 +646,7 @@ class C3DThreeAdapter {
             exportRoot,
             async (gltfInput: any) => {
                 const gltf = gltfInput;
-                const dir = await this._ensureExportDir();
+                const dir = await exportDirPromise;
 
                 const prefix = "data:application/octet-stream;base64,";
                 const uri = gltf.buffers?.[0]?.uri || "";
@@ -462,6 +698,8 @@ class C3DThreeAdapter {
     }
 
     public async exportObject(objectToExport: THREE.Object3D, objectName: string, renderer: THREE.WebGLRenderer, camera: THREE.Camera): Promise<void> {
+        const exportDirPromise = this._ensureExportDir();
+        const exportFileStem = this._getExportFileStem(objectName);
         const xrManager = renderer.xr as ExtendedWebXRManager;
         const originalScene = xrManager.isPresenting ? xrManager.getScene?.() : camera.parent; 
         const tempScene = new THREE.Scene();
@@ -494,7 +732,7 @@ class C3DThreeAdapter {
             gltfClone,
             async (gltfInput: any) => { 
                 const gltf = gltfInput;
-                const dir = await this._ensureExportDir();
+                const dir = await exportDirPromise;
                 const prefix = "data:application/octet-stream;base64,";
                 const uri = gltf.buffers?.[0]?.uri || "";
                 let binBlob: Blob | null = null;
@@ -506,25 +744,25 @@ class C3DThreeAdapter {
                     for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
                     binBlob = new Blob([bytes.buffer], { type: "application/octet-stream" });
                     if (gltf.buffers && gltf.buffers[0]) {
-                        gltf.buffers[0].uri = `${objectName}.bin`;
+                        gltf.buffers[0].uri = `${exportFileStem}.bin`;
                     }
                 }
 
                 const gltfBlob = new Blob([JSON.stringify(gltf, null, 2)], { type: "model/gltf+json" });
 
                 if (dir) {
-                    if (binBlob) await this._writeFile(dir, `${objectName}.bin`, binBlob);
-                    await this._writeFile(dir, `${objectName}.gltf`, gltfBlob);
+                    if (binBlob) await this._writeFile(dir, `${exportFileStem}.bin`, binBlob);
+                    await this._writeFile(dir, `${exportFileStem}.gltf`, gltfBlob);
                     await this._writeFile(dir, "cvr_object_thumbnail.png", screenshotBlob);
-                    console.log(`Exported object files for '${objectName}' to the 'scene' directory.`);
+                    console.log(`Exported object files for '${objectName}' as '${exportFileStem}.*' to the 'scene' directory.`);
                 } else {
                     console.warn("File System Access API not available; falling back to zip download.");
                     const zip = new JSZip();
-                    if (binBlob) zip.file(`${objectName}.bin`, binBlob);
-                    zip.file(`${objectName}.gltf`, gltfBlob);
+                    if (binBlob) zip.file(`${exportFileStem}.bin`, binBlob);
+                    zip.file(`${exportFileStem}.gltf`, gltfBlob);
                     zip.file("cvr_object_thumbnail.png", screenshotBlob);
                     const zipBlob = await zip.generateAsync({ type: "blob" });
-                    this._downloadBlob(zipBlob, `${objectName}-export.zip`);
+                    this._downloadBlob(zipBlob, `${exportFileStem}-export.zip`);
                 }
             },
             (err) => {

--- a/src/dynamicobject.ts
+++ b/src/dynamicobject.ts
@@ -217,7 +217,7 @@ class DynamicObject {
         return newObjectId.id;
     }
 
-    trackObject(id: string, object: object, options: { positionThreshold?: number, rotationThreshold?: number, scaleThreshold?: number } = {}): void { 
+    trackObject(id: string, object: object, options: { positionThreshold?: number, rotationThreshold?: number, scaleThreshold?: number, useLocalScale?: boolean } = {}): void { 
         if (!id || !object) {
             console.error("DynamicObject.trackObject: id and object must be provided.");
             return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   XRSessionManager,
   getHMDInfo,
   getEnabledFeatures,
+  hasTrackedControllers,
   XRSessionManager as XRSessionManagerType,
   GazeHitData
 } from './utils/webxr';
@@ -39,7 +40,6 @@ interface C3DConstructorSettings {
 class C3D {
   public core: CognitiveVRAnalyticsCore;
   public xrSessionManager: XRSessionManagerType | null;
-  public gazeRaycaster: (() => GazeHitData | null) | null;
   public lastInputType: 'none' | 'hand' | 'controller';
   public network: Network;
   public gaze: GazeTracker;
@@ -56,6 +56,7 @@ class C3D {
   public renderer: any;    // Supports multiple engines (Three, Babylon, WLE) without shared interfaces
   public boundaryTracker: BoundaryTracker;
   private deviceIdPromise: Promise<void> | null = null;
+  private _gazeRaycaster: (() => GazeHitData | null) | null;
 
   constructor(settings?: C3DConstructorSettings, renderer: any = null) { 
     this.core = coreInstance;
@@ -65,7 +66,7 @@ class C3D {
     }
 
     this.xrSessionManager = null; 
-    this.gazeRaycaster = null;
+    this._gazeRaycaster = null;
 
     this.setUserProperty("c3d.version", this.core.config.SDKVersion);  
     this.lastInputType = 'none';
@@ -126,6 +127,17 @@ class C3D {
     }
   }
 
+  get gazeRaycaster(): (() => GazeHitData | null) | null {
+    return this._gazeRaycaster;
+  }
+
+  set gazeRaycaster(value: (() => GazeHitData | null) | null) {
+    this._gazeRaycaster = value;
+    if (this.xrSessionManager) {
+      this.xrSessionManager.setGazeRaycaster(value);
+    }
+  }
+
   private async initializeDeviceId(): Promise<void> {
     try {
         const fp = await FingerprintJS.load();
@@ -177,6 +189,17 @@ class C3D {
       }
 
       const referenceSpace = sessionInfo ? sessionInfo.referenceSpace : null;
+      const sessionMode = sessionInfo ? sessionInfo.sessionMode : null;
+      const referenceSpaceType = sessionInfo ? sessionInfo.referenceSpaceType : null;
+
+      if (sessionMode) {
+        this.setSessionProperty('c3d.session.xr.mode', sessionMode);
+      }
+      if (referenceSpaceType) {
+        this.setSessionProperty('c3d.session.xr.reference_space', referenceSpaceType);
+      }
+      this.setSessionProperty('c3d.session.xr.boundary_available', Boolean(sessionInfo && sessionInfo.boundedReferenceSpace));
+      this.setSessionProperty('c3d.device.controllerinputs.enabled', hasTrackedControllers(xrSession.inputSources));
 
       if (referenceSpace) {
         this.hmdOrientation.start(
@@ -194,7 +217,6 @@ class C3D {
       const features = getEnabledFeatures(xrSession);
       this.setDeviceProperty("HandTracking", features.handTracking);
       this.setDeviceProperty("EyeTracking", features.eyeTracking);
-      this.setSessionProperty("c3d.device.controllerinputs.enabled", true);
       if (features.handTracking) {
           this.setSessionProperty("c3d.app.handtracking.enabled", true);
       }
@@ -214,6 +236,7 @@ class C3D {
             // @ts-ignore
             const xrEvent = event as XRInputSourcesChangeEvent;
             const newHmdInfo = getHMDInfo(xrEvent.session.inputSources);
+            this.setSessionProperty('c3d.device.controllerinputs.enabled', hasTrackedControllers(xrEvent.session.inputSources));
             if (newHmdInfo) {
                 this.setDeviceProperty('VRModel', newHmdInfo.VRModel);
                 this.setDeviceProperty('VRVendor', newHmdInfo.VRVendor);
@@ -283,6 +306,22 @@ class C3D {
 
   getCurrentInputType(): 'hand' | 'controller' | 'none' {
       return this.lastInputType;
+  }
+
+  getXRSessionMode(): string | null {
+      return this.xrSessionManager ? this.xrSessionManager.sessionMode : null;
+  }
+
+  getXRReferenceSpaceType(): string | null {
+      return this.xrSessionManager ? this.xrSessionManager.referenceSpaceType : null;
+  }
+
+  isARSession(): boolean {
+      return this.getXRSessionMode() === 'immersive-ar';
+  }
+
+  isVRSession(): boolean {
+      return this.getXRSessionMode() === 'immersive-vr';
   }
 
   sceneData(name: string, id: string, version: string): SceneConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,10 +176,12 @@ class C3D {
     }
   }
 
-  async startSession(xrSession: XRSession | null = null): Promise<boolean> { 
+  async startSession(xrSession: XRSession | null = null): Promise<boolean> {
     if (this.core.isSessionActive) { return false; }
 
-    await this.waitForDeviceId();
+    if (this.deviceIdPromise) {
+      await this.waitForDeviceId();
+    }
   
     if (this.renderer) { 
       this.profiler.start(this.renderer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ interface C3DConstructorSettings {
 }
 
 class C3D {
+  private static readonly DEVICE_ID_WAIT_TIMEOUT_MS = 3000;
   public core: CognitiveVRAnalyticsCore;
   public xrSessionManager: XRSessionManagerType | null;
   public lastInputType: 'none' | 'hand' | 'controller';
@@ -151,12 +152,34 @@ class C3D {
     }
   }
 
+  private async waitForDeviceId(): Promise<void> {
+    if (!this.deviceIdPromise) {
+      return;
+    }
+
+    let didTimeout = false;
+
+    await Promise.race([
+      this.deviceIdPromise,
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          didTimeout = true;
+          resolve();
+        }, C3D.DEVICE_ID_WAIT_TIMEOUT_MS);
+      }),
+    ]);
+
+    if (didTimeout) {
+      console.warn(
+        `C3D: Device fingerprint initialization exceeded ${C3D.DEVICE_ID_WAIT_TIMEOUT_MS}ms. Continuing session startup without waiting for it.`,
+      );
+    }
+  }
+
   async startSession(xrSession: XRSession | null = null): Promise<boolean> { 
     if (this.core.isSessionActive) { return false; }
 
-    if (this.deviceIdPromise) {
-        await this.deviceIdPromise;
-    }
+    await this.waitForDeviceId();
   
     if (this.renderer) { 
       this.profiler.start(this.renderer);

--- a/src/utils/webxr.ts
+++ b/src/utils/webxr.ts
@@ -11,6 +11,8 @@ export interface GazeHitData {
     point: number[];
 }
 
+type XRSessionModeValue = 'immersive-ar' | 'immersive-vr' | 'inline' | string;
+
 // Dependencies interfaces
 interface GazeTracker {
     recordGaze: (_position: number[], orientation: number[], gazeHitData: GazeHitData | number[] | null) => void;
@@ -24,7 +26,13 @@ export type GazeRaycaster = () => GazeHitData | null;
 
 interface SessionStartResult {
     referenceSpace: XRReferenceSpace | null;
+    referenceSpaceType: string | null;
     boundedReferenceSpace: XRReferenceSpace | null;
+    sessionMode: XRSessionModeValue | null;
+}
+
+interface ReferenceSpaceResult {
+    referenceSpace: XRReferenceSpace | null;
     type: string | null;
 }
 
@@ -38,6 +46,7 @@ export class XRSessionManager {
   public referenceSpace: XRReferenceSpace | null;  // For gaze tracking (local-floor)
   public boundedReferenceSpace: XRReferenceSpace | null; // For boundary tracking (bounded-floor)
   public referenceSpaceType: string | null;
+  public sessionMode: XRSessionModeValue | null;
   
   private isTracking: boolean;
   private animationFrameHandle: number | null;
@@ -52,6 +61,7 @@ export class XRSessionManager {
     this.referenceSpace = null;  // For gaze tracking (local-floor)
     this.boundedReferenceSpace = null; // For boundary tracking (bounded-floor)
     this.referenceSpaceType = null;
+    this.sessionMode = null;
     this.isTracking = false; 
     this.animationFrameHandle = null;
     this.onXRFrame = this.onXRFrame.bind(this);
@@ -59,38 +69,47 @@ export class XRSessionManager {
     this.interval = 100; 
   }
 
+  setGazeRaycaster(gazeRaycaster: GazeRaycaster | null): void {
+      this.gazeRaycaster = gazeRaycaster;
+  }
+
   async start(): Promise<SessionStartResult | null> {
       if (this.isTracking) return { 
           referenceSpace: this.referenceSpace, 
+          referenceSpaceType: this.referenceSpaceType,
           boundedReferenceSpace: this.boundedReferenceSpace,
-          type: this.referenceSpaceType 
+          sessionMode: this.sessionMode
       };
-      
-      // 1. ALWAYS get local-floor for gaze tracking
-      try {
-          this.referenceSpace = await this.xrSession.requestReferenceSpace('local-floor');
-          console.log('Cog3D-XR-Session-Manager: Using "local-floor" for gaze tracking.');
-      } catch (error) {
-          console.warn('Cog3D-XR-Session-Manager: "local-floor" not supported, falling back to "local".', error);
-          try {
-              this.referenceSpace = await this.xrSession.requestReferenceSpace('local');
-              console.log('Cog3D-XR-Session-Manager: Using "local" for gaze tracking.');
-          } catch (finalError) {
-              console.error('Cog3D-XR-Session-Manager: Failed to get reference space for gaze.', finalError);
-              return null;
-          }
+
+      this.sessionMode = getSessionMode(this.xrSession);
+
+      const preferredReferenceSpaces = this.sessionMode === 'immersive-ar'
+          ? ['local', 'local-floor']
+          : ['local-floor', 'local'];
+
+      const referenceSpaceResult = await this._requestFirstSupportedReferenceSpace(preferredReferenceSpaces);
+      if (!referenceSpaceResult.referenceSpace) {
+          console.error('Cog3D-XR-Session-Manager: Failed to get reference space for gaze.');
+          return null;
       }
-      
+
+      this.referenceSpace = referenceSpaceResult.referenceSpace;
+      this.referenceSpaceType = referenceSpaceResult.type;
+      console.log(`Cog3D-XR-Session-Manager: Using "${this.referenceSpaceType}" for ${this.sessionMode || 'xr'} gaze tracking.`);
+
       // 2. Try to get bounded-floor for boundary tracking (optional)
-      try {
-          // @ts-ignore: 'bounded-floor' might not be in standard definitions depending on tsconfig lib
-          this.boundedReferenceSpace = await this.xrSession.requestReferenceSpace('bounded-floor');
-          this.referenceSpaceType = 'bounded-floor';
-          console.log('Cog3D-XR-Session-Manager: "bounded-floor" available for boundary tracking.');
-      } catch (error) {
-          console.warn('Cog3D-XR-Session-Manager: "bounded-floor" not available. Boundary tracking disabled.', error);
+      if (this.sessionMode !== 'immersive-ar') {
+          try {
+              // @ts-ignore: 'bounded-floor' might not be in standard definitions depending on tsconfig lib
+              this.boundedReferenceSpace = await this.xrSession.requestReferenceSpace('bounded-floor');
+              console.log('Cog3D-XR-Session-Manager: "bounded-floor" available for boundary tracking.');
+          } catch (error) {
+              console.warn('Cog3D-XR-Session-Manager: "bounded-floor" not available. Boundary tracking disabled.', error);
+              this.boundedReferenceSpace = null;
+          }
+      } else {
           this.boundedReferenceSpace = null;
-          this.referenceSpaceType = 'local-floor';
+          console.log('Cog3D-XR-Session-Manager: Skipping bounded-floor lookup for immersive-ar session.');
       }
       
       this.isTracking = true;
@@ -99,8 +118,28 @@ export class XRSessionManager {
       
       return {
           referenceSpace: this.referenceSpace,  // local-floor for gaze
+          referenceSpaceType: this.referenceSpaceType,
           boundedReferenceSpace: this.boundedReferenceSpace,  // bounded-floor for boundaries
-          type: this.referenceSpaceType
+          sessionMode: this.sessionMode
+      };
+  }
+
+  private async _requestFirstSupportedReferenceSpace(candidates: string[]): Promise<ReferenceSpaceResult> {
+      for (const candidate of candidates) {
+          try {
+              const referenceSpace = await this.xrSession.requestReferenceSpace(candidate as XRReferenceSpaceType);
+              return {
+                  referenceSpace,
+                  type: candidate
+              };
+          } catch (error) {
+              console.warn(`Cog3D-XR-Session-Manager: "${candidate}" not supported. Trying next reference space.`, error);
+          }
+      }
+
+      return {
+          referenceSpace: null,
+          type: null
       };
   }
   
@@ -146,9 +185,27 @@ export class XRSessionManager {
     if (this.animationFrameHandle) {
       this.xrSession.cancelAnimationFrame(this.animationFrameHandle);
     }
+    this.referenceSpace = null;
+    this.referenceSpaceType = null;
+    this.boundedReferenceSpace = null;
+    this.sessionMode = null;
     console.log('Cog3D-XR-Session-Manager: Gaze tracking stopped.');
   }
 }
+
+export const getSessionMode = (xrSession: XRSession): XRSessionModeValue | null => {
+    const sessionWithMode = xrSession as unknown as { mode?: XRSessionModeValue };
+    return sessionWithMode.mode || null;
+};
+
+export const hasTrackedControllers = (inputSources: XRInputSourceArray | XRInputSource[]): boolean => {
+    for (const source of inputSources) {
+        if (!source.hand && source.targetRayMode === 'tracked-pointer' && source.gripSpace) {
+            return true;
+        }
+    }
+    return false;
+};
 
 // Controller (profile identifier) lookup table to infer HMD Device, note that headset can be different from controller brand 
 const HMD_PROFILE_MAP: { [key: string]: { VRModel: string; VRVendor: string } } = {

--- a/src/utils/webxr.ts
+++ b/src/utils/webxr.ts
@@ -100,7 +100,6 @@ export class XRSessionManager {
       // 2. Try to get bounded-floor for boundary tracking (optional)
       if (this.sessionMode !== 'immersive-ar') {
           try {
-              // @ts-ignore: 'bounded-floor' might not be in standard definitions depending on tsconfig lib
               this.boundedReferenceSpace = await this.xrSession.requestReferenceSpace('bounded-floor');
               console.log('Cog3D-XR-Session-Manager: "bounded-floor" available for boundary tracking.');
           } catch (error) {


### PR DESCRIPTION
  **Overview**
 This PR adds Mobile AR session support and a series of engine gaze pipeline improvements. 

  **Changes**

  * AR-aware `XRSessionManager` with mode-specific reference space selection and new `isARSession` / `isVRSession` helpers
  * Analytics origin system (`setAnalyticsOrigin`, `transformWorldToAnalyticsOrigin`) for recording poses in a chosen frame
  * WebAR-only gaze fixes: 60 Hz cap, synthetic forward endpoint, 200 ms last-hit cache, raycaster refactor
  * `useLocalScale` option on `trackDynamicObject`, 3 s timeout on device fingerprint, stale `@ts-ignore` removed
  * New tests for engine gaze interval behaviour and AR session reference space selection

  **Tooling**
  * `waitForDeviceId` adds a 3 s timeout so fingerprint hangs don't block session startup, with the sync fast-path preserved when no fingerprint is in flight.
  * Drops a stale `@ts-ignore` since `@types/webxr` already covers `bounded-floor`.
  * Adds tests for engine gaze interval behaviour and AR session reference space selection.