### PR TITLE
Send raw device signals; remove in-SDK device classification

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -22,7 +22,8 @@
           "targets": {
             "node": "current"
           }
-        }]
+        }],
+        "@babel/preset-typescript"
       ]
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ package_lock.json
 types/
 
 **/.DS_Store
+docs/audits/webxr-device-signal-audit-delta-2026-07.md
+docs/audits/webxr-device-signal-audit.md

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ types/
 **/.DS_Store
 docs/audits/webxr-device-signal-audit-delta-2026-07.md
 docs/audits/webxr-device-signal-audit.md
+docs/audits/2026-07-08-raw-device-signals-design.md

--- a/__tests__/controller-mesh-test.js
+++ b/__tests__/controller-mesh-test.js
@@ -1,0 +1,46 @@
+/**
+ * Unit coverage for ControllerInputTracker's mesh resolution (C3D-1726).
+ *
+ * `resolveControllerMesh` is rendering config only — it picks the dashboard mesh from raw
+ * WebXR profiles and must NOT classify controller identity (that now rides on the raw
+ * `inputProfiles` sent alongside). These tests lock in: correct handed mesh, specific-
+ * before-generic profile matching, and the mesh-only `fallbackController` behavior.
+ */
+import { resolveControllerMesh } from '../src/utils/ControllerInputTracker';
+
+// Silence the intentional "unrecognized profile" warnings for the fallback/unknown cases.
+beforeAll(() => jest.spyOn(console, 'warn').mockImplementation(() => {}));
+afterAll(() => console.warn.mockRestore());
+
+test('resolves the handed mesh for a recognized profile', () => {
+    expect(resolveControllerMesh(['meta-quest-touch-plus'], 'left')).toBe('QuestPlusTouchLeft');
+    expect(resolveControllerMesh(['meta-quest-touch-plus'], 'right')).toBe('QuestPlusTouchRight');
+});
+
+test('matches more-specific profiles before their shorter substrings', () => {
+    // 'oculus-touch-v3' must win over the bare 'oculus-touch' key.
+    expect(resolveControllerMesh(['oculus-touch-v3'], 'left')).toBe('OculusQuestTouchLeft');
+    expect(resolveControllerMesh(['oculus-touch'], 'left')).toBe('OculusRiftTouchLeft');
+    // 'htc-vive-focus-3' must win over 'htc-vive'.
+    expect(resolveControllerMesh(['htc-vive-focus-3'], 'right')).toBe('ViveFocusControllerRight');
+    expect(resolveControllerMesh(['htc-vive'], 'right')).toBe('ViveController');
+});
+
+test('matches case-insensitively and ignores unrecognized companion profiles', () => {
+    expect(resolveControllerMesh(['Valve-Index'], 'left')).toBe('SteamIndexLeft');
+    expect(
+        resolveControllerMesh(['meta-quest-touch-plus', 'generic-trigger-squeeze-thumbstick'], 'left'),
+    ).toBe('QuestPlusTouchLeft');
+});
+
+test('falls back to the generic mesh for unrecognized profiles with no fallback', () => {
+    expect(resolveControllerMesh(['some-unknown-controller'], 'left')).toBe('GenericController');
+    expect(resolveControllerMesh([], 'right')).toBe('GenericController');
+});
+
+test('fallbackController selects a mesh (only) when profiles are unrecognized', () => {
+    // A valid fallback key resolves to that controller's mesh...
+    expect(resolveControllerMesh(['some-unknown'], 'right', 'valve-index')).toBe('SteamIndexRight');
+    // ...but a fallback that is not itself a valid map key degrades to the generic mesh.
+    expect(resolveControllerMesh(['some-unknown'], 'left', 'not-a-real-profile')).toBe('GenericController');
+});

--- a/__tests__/device-signals-test.js
+++ b/__tests__/device-signals-test.js
@@ -87,6 +87,15 @@ function createXRSessionMock({ mode, localFloorSpace, boundedFloorSpace, inputSo
     };
 }
 
+// The SDK core (coreInstance) is a singleton shared across every test in this file. Reset it
+// before each test so leaked state — e.g. a prior test that started a session without ending it,
+// leaving core.isSessionActive === true — can't bleed across tests and make them order-dependent.
+beforeEach(() => {
+    const c3d = new C3DAnalytics(settings);
+    c3d.core.setSessionStatus = false;
+    c3d.core.resetNewUserDeviceProperties();
+});
+
 test('Captures raw device-identity signals at construction (desktop profile)', () => {
     stubEnvironment({
         userAgent:
@@ -111,10 +120,14 @@ test('Captures raw device-identity signals at construction (desktop profile)', (
 
     // Raw UA + UA-CH, verbatim (no classification into OS/browser/device-type).
     expect(dp['c3d.device.user_agent']).toContain('Edg/120.0.0.0');
-    expect(dp['c3d.device.ua_brands']).toEqual([
-        { brand: 'Microsoft Edge', version: '120' },
-        { brand: 'Chromium', version: '120' },
-    ]);
+    // ua_brands is JSON-serialized to a scalar string so it survives ingestion (the pipeline
+    // drops array/object-valued session properties); the full raw data is preserved.
+    expect(dp['c3d.device.ua_brands']).toBe(
+        JSON.stringify([
+            { brand: 'Microsoft Edge', version: '120' },
+            { brand: 'Chromium', version: '120' },
+        ]),
+    );
     // Falsy-but-meaningful values must still be sent (guarded on !== null, not truthiness).
     expect(dp['c3d.device.ua_mobile']).toBe(false);
     expect(dp['c3d.device.max_touch_points']).toBe(0);
@@ -196,14 +209,39 @@ test('Sends raw XR input profiles instead of a classified HMD type/vendor', asyn
     await expect(c3d.startSession(xrSession)).resolves.toBe(true);
     const dp = c3d.getDeviceProperties();
 
-    // Flattened + de-duplicated raw profiles across both input sources.
-    expect(dp['c3d.device.xr.input_profiles']).toEqual([
-        'meta-quest-touch-plus',
-        'generic-trigger-squeeze-thumbstick',
-    ]);
+    // Union of raw profiles across both input sources, de-duplicated, sent as a comma-joined
+    // scalar string (arrays are dropped by ingestion).
+    expect(dp['c3d.device.xr.input_profiles']).toBe(
+        'meta-quest-touch-plus,generic-trigger-squeeze-thumbstick',
+    );
     // The classified keys are gone entirely.
     expect(dp['c3d.device.hmd.type']).toBeUndefined();
     expect(dp['c3d.device.vendor']).toBeUndefined();
+});
+
+test('input_profiles accumulates across controller churn (union, not overwrite)', async () => {
+    let changeHandler = null;
+    const xrSession = createXRSessionMock({
+        mode: 'immersive-vr',
+        localFloorSpace: { kind: 'local-floor' },
+        boundedFloorSpace: { kind: 'bounded-floor', boundsGeometry: [] },
+        inputSources: [
+            { handedness: 'right', targetRayMode: 'tracked-pointer', gripSpace: { kind: 'grip' }, profiles: ['meta-quest-touch-plus'] },
+        ],
+    });
+    // Capture the inputsourceschange listener the SDK registers so we can simulate churn.
+    xrSession.addEventListener = jest.fn((type, cb) => { if (type === 'inputsourceschange') changeHandler = cb; });
+
+    const c3d = makeC3D();
+    c3d.customEvent.send = jest.fn();
+    await expect(c3d.startSession(xrSession)).resolves.toBe(true);
+    expect(c3d.getDeviceProperties()['c3d.device.xr.input_profiles']).toBe('meta-quest-touch-plus');
+
+    // Controllers sleep / user switches to hand-tracking: inputsourceschange fires with NO
+    // controller profiles. The headset fingerprint captured earlier must NOT be erased.
+    expect(typeof changeHandler).toBe('function');
+    changeHandler({ session: { inputSources: [] } });
+    expect(c3d.getDeviceProperties()['c3d.device.xr.input_profiles']).toBe('meta-quest-touch-plus');
 });
 
 test('Controller manifest carries raw input profiles, not a classified controllerType', () => {

--- a/__tests__/device-signals-test.js
+++ b/__tests__/device-signals-test.js
@@ -263,6 +263,23 @@ test('Controller manifest carries raw input profiles, not a classified controlle
     expect(entry.controllerType).toBeUndefined();
 });
 
+test('registerControllerObject stays backward-compatible with a legacy string 6th arg', () => {
+    const c3d = makeC3D();
+
+    // Older callers passed a classified controllerType STRING as the 6th argument. It must not
+    // break or land as a non-array value: the string is coerced to a single-element array.
+    c3d.dynamicObject.registerControllerObject(
+        'Left Controller', 'GenericController', 'c3d_controller_left',
+        [0, 0, 0], [0, 0, 0, 1],
+        'quest_plus_touch_left', // legacy string, not an array
+        'left',
+    );
+
+    const entry = c3d.dynamicObject.manifestEntries.find((e) => e.id === 'c3d_controller_left');
+    expect(entry).toBeDefined();
+    expect(entry.inputProfiles).toEqual(['quest_plus_touch_left']);
+});
+
 test('setHMDType() is retained as a deprecated no-op that warns (no crash)', () => {
     const c3d = makeC3D();
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/__tests__/device-signals-test.js
+++ b/__tests__/device-signals-test.js
@@ -1,0 +1,247 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Raw device-signal coverage (C3D-1726). Verifies the SDK sends RAW signals and does no
+ * in-SDK device classification: raw UA / UA-CH / touch / GPU-vendor / memory at construction,
+ * and raw WebXR input profiles (not a classified HMD/controller identity) during a session.
+ *
+ * Hermetic: c3d.sendData (and customEvent.send for the session test) are mocked so no real
+ * backend flush occurs — assertions read in-memory session/device properties only.
+ */
+import C3DAnalytics from '../lib/cjs/index.cjs.js';
+
+const settings = {
+    config: {
+        APIKey: 'test-api-key',
+        networkHost: 'data.cognitive3d.com',
+        allSceneData: [
+            {
+                sceneName: 'BasicScene',
+                sceneId: '93f486e4-0e22-4650-946a-e64ce527f915',
+                versionNumber: '1',
+            },
+        ],
+    },
+};
+
+const scene1 = settings.config.allSceneData[0].sceneName;
+
+// Fake WebGL param keys — arbitrary, matched by getParameter below.
+const UNMASKED_VENDOR = 0x9245;
+const UNMASKED_RENDERER = 0x9246;
+
+function defineNav(prop, value) {
+    Object.defineProperty(navigator, prop, { value, configurable: true });
+}
+
+// Stub the browser globals the SDK reads at construction, BEFORE constructing C3DAnalytics.
+function stubEnvironment(opts = {}) {
+    const { userAgent, uaData, deviceMemory, maxTouchPoints, pointerCoarse, hoverHover, gpuVendor, gpuRenderer } = opts;
+
+    if (userAgent !== undefined) defineNav('userAgent', userAgent);
+    if (uaData !== undefined) defineNav('userAgentData', uaData);
+    if (deviceMemory !== undefined) defineNav('deviceMemory', deviceMemory);
+    if (maxTouchPoints !== undefined) defineNav('maxTouchPoints', maxTouchPoints);
+
+    window.matchMedia = jest.fn((query) => ({
+        matches: query.includes('pointer: coarse')
+            ? Boolean(pointerCoarse)
+            : query.includes('hover: hover')
+                ? Boolean(hoverHover)
+                : false,
+        media: query,
+    }));
+
+    const fakeGl = {
+        getExtension: (name) =>
+            name === 'WEBGL_debug_renderer_info'
+                ? { UNMASKED_VENDOR_WEBGL: UNMASKED_VENDOR, UNMASKED_RENDERER_WEBGL: UNMASKED_RENDERER }
+                : null,
+        getParameter: (p) => (p === UNMASKED_VENDOR ? gpuVendor : p === UNMASKED_RENDERER ? gpuRenderer : null),
+    };
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => fakeGl);
+}
+
+// Construct after stubbing the environment; mock the network flush so setScene stays hermetic.
+function makeC3D() {
+    const c3d = new C3DAnalytics(settings);
+    c3d.sendData = jest.fn().mockResolvedValue(200);
+    c3d.setScene(scene1);
+    return c3d;
+}
+
+function createXRSessionMock({ mode, localFloorSpace, boundedFloorSpace, inputSources = [] }) {
+    return {
+        mode,
+        inputSources,
+        enabledFeatures: [],
+        requestReferenceSpace: jest.fn((type) => {
+            if (type === 'local-floor' && localFloorSpace) return Promise.resolve(localFloorSpace);
+            if (type === 'bounded-floor' && boundedFloorSpace) return Promise.resolve(boundedFloorSpace);
+            return Promise.reject(new Error(`Unsupported reference space: ${type}`));
+        }),
+        requestAnimationFrame: jest.fn(() => 1),
+        cancelAnimationFrame: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    };
+}
+
+test('Captures raw device-identity signals at construction (desktop profile)', () => {
+    stubEnvironment({
+        userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+        uaData: {
+            mobile: false,
+            brands: [
+                { brand: 'Microsoft Edge', version: '120' },
+                { brand: 'Chromium', version: '120' },
+            ],
+        },
+        deviceMemory: 8,
+        maxTouchPoints: 0,
+        pointerCoarse: false,
+        hoverHover: true,
+        gpuVendor: 'Google Inc. (NVIDIA)',
+        gpuRenderer: 'ANGLE (NVIDIA, NVIDIA GeForce RTX 3080 Direct3D11)',
+    });
+
+    const c3d = makeC3D();
+    const dp = c3d.getDeviceProperties();
+
+    // Raw UA + UA-CH, verbatim (no classification into OS/browser/device-type).
+    expect(dp['c3d.device.user_agent']).toContain('Edg/120.0.0.0');
+    expect(dp['c3d.device.ua_brands']).toEqual([
+        { brand: 'Microsoft Edge', version: '120' },
+        { brand: 'Chromium', version: '120' },
+    ]);
+    // Falsy-but-meaningful values must still be sent (guarded on !== null, not truthiness).
+    expect(dp['c3d.device.ua_mobile']).toBe(false);
+    expect(dp['c3d.device.max_touch_points']).toBe(0);
+    expect(dp['c3d.device.pointer_coarse']).toBe(false);
+    expect(dp['c3d.device.hover_hover']).toBe(true);
+
+    // Memory: legacy MB kept for pipeline continuity; raw GB added under a unit-suffixed key.
+    expect(dp['c3d.device.memory']).toBe(8000);
+    expect(dp['c3d.device.memoryInGB']).toBe(8);
+
+    // Raw GPU strings, verbatim.
+    expect(dp['c3d.device.gpu']).toBe('ANGLE (NVIDIA, NVIDIA GeForce RTX 3080 Direct3D11)');
+    expect(dp['c3d.device.gpu.vendor']).toBe('Google Inc. (NVIDIA)');
+});
+
+test('Captures raw touch/mobile signals for a phone profile', () => {
+    stubEnvironment({
+        userAgent: 'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+        uaData: { mobile: true, brands: [{ brand: 'Chromium', version: '120' }] },
+        deviceMemory: 4,
+        maxTouchPoints: 5,
+        pointerCoarse: true,
+        hoverHover: false,
+        gpuVendor: 'Google Inc. (Qualcomm)',
+        gpuRenderer: 'ANGLE (Qualcomm, Adreno (TM) 650)',
+    });
+
+    const c3d = makeC3D();
+    const dp = c3d.getDeviceProperties();
+
+    expect(dp['c3d.device.ua_mobile']).toBe(true);
+    expect(dp['c3d.device.max_touch_points']).toBe(5);
+    expect(dp['c3d.device.pointer_coarse']).toBe(true);
+    expect(dp['c3d.device.hover_hover']).toBe(false);
+});
+
+test('Does not override GPU vendor for Adreno renderers (raw UNMASKED_VENDOR preserved)', () => {
+    stubEnvironment({
+        deviceMemory: 4,
+        maxTouchPoints: 5,
+        pointerCoarse: true,
+        hoverHover: false,
+        gpuVendor: 'Google Inc. (Qualcomm)',
+        gpuRenderer: 'ANGLE (Qualcomm, Adreno (TM) 650)',
+    });
+
+    const c3d = makeC3D();
+    const dp = c3d.getDeviceProperties();
+
+    // The removed override would have forced the bare string "Qualcomm"; the raw value must survive.
+    expect(dp['c3d.device.gpu.vendor']).toBe('Google Inc. (Qualcomm)');
+    expect(dp['c3d.device.gpu.vendor']).not.toBe('Qualcomm');
+});
+
+test('Sends raw XR input profiles instead of a classified HMD type/vendor', async () => {
+    const xrSession = createXRSessionMock({
+        mode: 'immersive-vr',
+        localFloorSpace: { kind: 'local-floor' },
+        boundedFloorSpace: { kind: 'bounded-floor', boundsGeometry: [] },
+        inputSources: [
+            {
+                handedness: 'left',
+                targetRayMode: 'tracked-pointer',
+                gripSpace: { kind: 'controller-grip' },
+                profiles: ['meta-quest-touch-plus', 'generic-trigger-squeeze-thumbstick'],
+            },
+            {
+                handedness: 'right',
+                targetRayMode: 'tracked-pointer',
+                gripSpace: { kind: 'controller-grip' },
+                profiles: ['meta-quest-touch-plus', 'generic-trigger-squeeze-thumbstick'],
+            },
+        ],
+    });
+
+    const c3d = makeC3D();
+    c3d.customEvent.send = jest.fn(); // avoid the 'Session Start' backend call
+
+    await expect(c3d.startSession(xrSession)).resolves.toBe(true);
+    const dp = c3d.getDeviceProperties();
+
+    // Flattened + de-duplicated raw profiles across both input sources.
+    expect(dp['c3d.device.xr.input_profiles']).toEqual([
+        'meta-quest-touch-plus',
+        'generic-trigger-squeeze-thumbstick',
+    ]);
+    // The classified keys are gone entirely.
+    expect(dp['c3d.device.hmd.type']).toBeUndefined();
+    expect(dp['c3d.device.vendor']).toBeUndefined();
+});
+
+test('Controller manifest carries raw input profiles, not a classified controllerType', () => {
+    const c3d = makeC3D();
+
+    c3d.dynamicObject.registerControllerObject(
+        'Right Controller',
+        'QuestPlusTouchRight',
+        'c3d_controller_right',
+        [0, 0, 0],
+        [0, 0, 0, 1],
+        ['meta-quest-touch-plus', 'generic-trigger-squeeze-thumbstick'],
+        'right',
+    );
+
+    const entry = c3d.dynamicObject.manifestEntries.find((e) => e.id === 'c3d_controller_right');
+    expect(entry).toBeDefined();
+    expect(entry.inputProfiles).toEqual(['meta-quest-touch-plus', 'generic-trigger-squeeze-thumbstick']);
+    expect(entry.controllerType).toBeUndefined();
+});
+
+test('setHMDType() is retained as a deprecated no-op that warns (no crash)', () => {
+    const c3d = makeC3D();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(() => c3d.gaze.setHMDType('Quest 3')).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
+
+    warnSpy.mockRestore();
+});
+
+test('the deprecated HMDType config setting warns when provided', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const c3d = new C3DAnalytics({ config: { ...settings.config, HMDType: 'Quest 3' } });
+    c3d.sendData = jest.fn().mockResolvedValue(200);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('HMDType'));
+
+    warnSpy.mockRestore();
+});

--- a/__tests__/mobile-ar-session-test.js
+++ b/__tests__/mobile-ar-session-test.js
@@ -99,7 +99,10 @@ test('Keep local-floor and tracked controller behavior for immersive-vr sessions
     expect(c3d.core.sessionProperties['c3d.session.xr.reference_space']).toEqual('local-floor');
     expect(c3d.core.sessionProperties['c3d.session.xr.boundary_available']).toBe(true);
     expect(c3d.core.sessionProperties['c3d.device.controllerinputs.enabled']).toBe(true);
-    expect(c3d.getDeviceProperties()['c3d.device.hmd.type']).toEqual('Quest 2');
+    // Raw input profiles replace the removed classified c3d.device.hmd.type / c3d.device.vendor.
+    expect(c3d.getDeviceProperties()['c3d.device.xr.input_profiles']).toEqual(['oculus-touch-v3']);
+    expect(c3d.getDeviceProperties()['c3d.device.hmd.type']).toBeUndefined();
+    expect(c3d.getDeviceProperties()['c3d.device.vendor']).toBeUndefined();
 
     await expect(c3d.endSession()).resolves.toEqual(200);
 });

--- a/__tests__/mobile-ar-session-test.js
+++ b/__tests__/mobile-ar-session-test.js
@@ -100,7 +100,7 @@ test('Keep local-floor and tracked controller behavior for immersive-vr sessions
     expect(c3d.core.sessionProperties['c3d.session.xr.boundary_available']).toBe(true);
     expect(c3d.core.sessionProperties['c3d.device.controllerinputs.enabled']).toBe(true);
     // Raw input profiles replace the removed classified c3d.device.hmd.type / c3d.device.vendor.
-    expect(c3d.getDeviceProperties()['c3d.device.xr.input_profiles']).toEqual(['oculus-touch-v3']);
+    expect(c3d.getDeviceProperties()['c3d.device.xr.input_profiles']).toBe('oculus-touch-v3');
     expect(c3d.getDeviceProperties()['c3d.device.hmd.type']).toBeUndefined();
     expect(c3d.getDeviceProperties()['c3d.device.vendor']).toBeUndefined();
 

--- a/cspell.json
+++ b/cspell.json
@@ -13,7 +13,6 @@
         "babylonjs",
         "fingerprintjs",
         "wonderlandengine",
-        "hmdtype",
         "roomsize",
         "customevent",
         "dynamicobject",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive3d/analytics",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "This SDK allows you to integrate your Javascript Applications with Cognitive3D, which provides analytics and insights about your VR/AR/MR project.",
   "main": "lib/cjs/index.cjs.js",
   "module": "lib/esm/index.esm.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface Settings {
     customEventBatchSize?: number;
     gazeBatchSize?: number;
     GazeInterval?: number;
+    /** @deprecated No longer has any effect; see GazeTracker.setHMDType. */
     HMDType?: string;
     gazeTrackingSource?: 'webxr' | 'engine';
     fallbackController?: string;
@@ -39,6 +40,7 @@ class Config {
     public gazeBatchSize: number;
     public GazeInterval: number;
     public allSceneData: SceneConfig[];
+    /** @deprecated No longer has any effect; retained for backward compatibility. */
     public HMDType?: string;
     public gazeTrackingSource: 'webxr' | 'engine';
     public fallbackController?: string;
@@ -76,6 +78,10 @@ class Config {
      */
     set settings(settings: Settings) {
         if (settings.LOG !== undefined) this.LOG = settings.LOG;
+
+        if (settings.HMDType !== undefined) {
+            console.warn('C3D: the `HMDType` setting is deprecated and has no effect. HMD identity is derived from the raw c3d.device.xr.input_profiles device signal.');
+        }
 
         // Map Settings keys to Config keys
         const keys: (keyof Settings)[] = [

--- a/src/core.ts
+++ b/src/core.ts
@@ -44,6 +44,7 @@ export class CognitiveVRAnalyticsCore {
             DeviceType: 'c3d.device.type',
             DeviceModel: 'c3d.device.model',
             DeviceMemory: 'c3d.device.memory',
+            DeviceMemoryGB: 'c3d.device.memoryInGB',
             DeviceOS: 'c3d.device.os',
             DevicePlatform: 'c3d.device.platform',
             DeviceCPU: 'c3d.device.cpu',
@@ -55,6 +56,15 @@ export class CognitiveVRAnalyticsCore {
             DeviceGPUMemory: 'c3d.device.gpu.memory',
             DeviceScreenHeight: 'c3d.device.screen.height',
             DeviceScreenWidth: 'c3d.device.screen.width',
+            DeviceMaxTouchPoints: 'c3d.device.max_touch_points',
+            DevicePointerCoarse: 'c3d.device.pointer_coarse',
+            DeviceHoverHover: 'c3d.device.hover_hover',
+            UserAgent: 'c3d.device.user_agent',
+            UABrands: 'c3d.device.ua_brands',
+            UAMobile: 'c3d.device.ua_mobile',
+            // Raw WebXR input profiles — replaces the removed classified
+            // c3d.device.hmd.type / c3d.device.vendor (pipeline resolves identity).
+            XRInputProfiles: 'c3d.device.xr.input_profiles',
             EyeTracking: 'c3d.device.eyetracking.enabled',
             HandTracking: 'c3d.app.handtracking.enabled',
             NetworkEffectiveType: 'c3d.network.effectiveType',
@@ -62,8 +72,6 @@ export class CognitiveVRAnalyticsCore {
             NetworkRTT: 'c3d.network.rtt',
             SDKType: 'c3d.sdk.type',
             SDKVersion: 'c3d.sdk.version',
-            VRModel: 'c3d.device.hmd.type',
-            VRVendor: 'c3d.device.vendor',
         };
     }
 

--- a/src/dynamicobject.ts
+++ b/src/dynamicobject.ts
@@ -375,8 +375,16 @@ class DynamicObject {
     registerControllerObject(
         name: string, meshname: string, customid: string,
         position: number[], rotation: number[],
-        inputProfiles: string[], handedness: 'left' | 'right'
+        inputProfiles: string[] | string, handedness: 'left' | 'right'
     ): string {
+        // Backward compatibility: the 6th argument was previously a classified `controllerType`
+        // string. That classification was removed in favor of raw WebXR input profiles, but this
+        // method is publicly reachable, so accept a string too and coerce it to a single-element
+        // array — older callers keep working and never write a non-array `inputProfiles` value.
+        const profiles: string[] = Array.isArray(inputProfiles)
+            ? inputProfiles
+            : (inputProfiles ? [inputProfiles] : []);
+
         for (let i = 0; i < this.objectIds.length; i++) {
             if (this.objectIds[i].id === customid) {
                 console.log("DynamicObject.registerControllerObject object id " + customid + " already registered");
@@ -391,7 +399,7 @@ class DynamicObject {
             name,
             mesh: meshname,
             fileType: 'gltf',
-            inputProfiles,
+            inputProfiles: profiles,
             properties: [{ controller: handedness }],
         };
         this.manifestEntries.push(dome);

--- a/src/dynamicobject.ts
+++ b/src/dynamicobject.ts
@@ -19,7 +19,7 @@ export interface ManifestEntry {
     name: string;
     mesh: string;
     fileType: string;
-    controllerType?: string;
+    inputProfiles?: string[];
     properties?: Array<Record<string, any>>;
 }
 
@@ -52,7 +52,7 @@ interface ManifestPayloadEntry {
     name: string;
     mesh: string;
     fileType: string;
-    controllerType?: string;
+    inputProfiles?: string[];
     properties?: Array<Record<string, any>>;
 }
 
@@ -332,7 +332,7 @@ class DynamicObject {
                 mesh: element.mesh,
                 fileType: "gltf"
             };
-            if (element.controllerType) entry.controllerType = element.controllerType;
+            if (element.inputProfiles?.length) entry.inputProfiles = element.inputProfiles;
             if (element.properties) entry.properties = element.properties;
             manifest[element.id] = entry;
         }
@@ -375,7 +375,7 @@ class DynamicObject {
     registerControllerObject(
         name: string, meshname: string, customid: string,
         position: number[], rotation: number[],
-        controllerType: string, handedness: 'left' | 'right'
+        inputProfiles: string[], handedness: 'left' | 'right'
     ): string {
         for (let i = 0; i < this.objectIds.length; i++) {
             if (this.objectIds[i].id === customid) {
@@ -391,7 +391,7 @@ class DynamicObject {
             name,
             mesh: meshname,
             fileType: 'gltf',
-            controllerType,
+            inputProfiles,
             properties: [{ controller: handedness }],
         };
         this.manifestEntries.push(dome);

--- a/src/gazetracker.ts
+++ b/src/gazetracker.ts
@@ -23,7 +23,6 @@ interface GazePayload {
     sessionid: string;
     lobbyId?: string;
     part: number;
-    hmdtype?: string;
     interval?: number;
     data: GazeData[];
     properties?: Record<string, SessionPropertyValue>;
@@ -33,8 +32,7 @@ class GazeTracker {
     private core: CognitiveVRAnalyticsCore;
     private network: Network;
     private playerSnapshotInterval: number | undefined;
-    private HMDType: string | undefined;
-    public batchedGaze: GazeData[]; 
+    public batchedGaze: GazeData[];
     private jsonPart: number;
 
     constructor(core: CognitiveVRAnalyticsCore) {
@@ -42,7 +40,6 @@ class GazeTracker {
         // @ts-ignore
         this.network = new Network(core);
         this.playerSnapshotInterval = undefined;
-        this.HMDType = undefined;
         this.batchedGaze = [];
         this.jsonPart = 1;
     }
@@ -82,8 +79,14 @@ class GazeTracker {
         this.playerSnapshotInterval = interval;
     }
 
-    setHMDType(hmdtype: string): void {
-        this.HMDType = hmdtype;
+    /**
+     * @deprecated The `hmdtype` gaze-payload shadow channel was removed. HMD identity is now
+     * derived by the pipeline from the raw `c3d.device.xr.input_profiles` device signal. This
+     * method is retained as a no-op for backward compatibility and will be removed in a future
+     * major version.
+     */
+    setHMDType(_hmdtype: string): void {
+        console.warn('C3D: setHMDType() is deprecated and has no effect. HMD identity is derived from the raw c3d.device.xr.input_profiles device signal.');
     }
 
     sendData(): Promise<number | string> {
@@ -136,7 +139,6 @@ class GazeTracker {
             timestamp: parseInt(this.core.getTimestamp() as unknown as string, 10),
             sessionid: this.core.getSessionId(),
             part: this.jsonPart,
-            hmdtype: this.HMDType,
             interval: this.playerSnapshotInterval,
             data: this.batchedGaze,
             properties: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,10 @@ class C3D {
 
     const uaBrands = getUABrands();
     if (uaBrands) {
-      this.setDeviceProperty('UABrands', uaBrands);
+      // Serialize to a JSON string: the ingestion pipeline drops array/object-valued session
+      // properties (verified), so the raw brands array must be sent as a scalar to land. The
+      // full raw data is preserved and the pipeline can JSON.parse or substring-match it.
+      this.setDeviceProperty('UABrands', JSON.stringify(uaBrands));
     }
 
     const uaMobile = getUAMobile();
@@ -293,13 +296,27 @@ class C3D {
 
     if (xrSession && xrSession.inputSources) {
         // Raw input profiles replace the removed classified c3d.device.hmd.type / c3d.device.vendor.
-        this.setDeviceProperty('XRInputProfiles', getInputProfiles(xrSession.inputSources));
+        // Two things to get right:
+        //  1. Accumulate the UNION of every profile seen across the session, not just the currently-
+        //     connected sources — controllers churn mid-session (sleep, lose tracking, or the user
+        //     switches to hand-tracking), and overwriting would erase the headset's hardware fingerprint.
+        //  2. Send it as a comma-joined STRING, not an array: the ingestion pipeline drops array-valued
+        //     session properties (verified), so an array would silently never reach the backend. Profile
+        //     ids contain no commas, and the pipeline substring-matches this string.
+        const seenInputProfiles = new Set<string>();
+        const recordInputProfiles = (inputSources: XRInputSourceArray | XRInputSource[]) => {
+            for (const profile of getInputProfiles(inputSources)) {
+                seenInputProfiles.add(profile);
+            }
+            this.setDeviceProperty('XRInputProfiles', Array.from(seenInputProfiles).join(','));
+        };
+        recordInputProfiles(xrSession.inputSources);
 
         xrSession.addEventListener('inputsourceschange', (event: XRInputSourcesChangeEvent) => {
             // @ts-ignore
             const xrEvent = event as XRInputSourcesChangeEvent;
             this.setSessionProperty('c3d.device.controllerinputs.enabled', hasTrackedControllers(xrEvent.session.inputSources));
-            this.setDeviceProperty('XRInputProfiles', getInputProfiles(xrEvent.session.inputSources));
+            recordInputProfiles(xrEvent.session.inputSources);
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,18 @@ import {
   getHardwareConcurrency,
   getConnection,
   getGPUInfo,
+  getUserAgent,
+  getUABrands,
+  getUAMobile,
+  getMaxTouchPoints,
+  getPointerCoarse,
+  getHoverHover,
   isBrowser
 } from './utils/environment';
 
-import { 
+import {
   XRSessionManager,
-  getHMDInfo,
+  getInputProfiles,
   getEnabledFeatures,
   hasTrackedControllers,
   XRSessionManager as XRSessionManagerType,
@@ -97,7 +103,10 @@ class C3D {
 
     const deviceMemory = getDeviceMemory();
     if (deviceMemory) {
-      this.setDeviceProperty('DeviceMemory', deviceMemory * 1000); 
+      // MB (legacy convention, no unit in key name; the pipeline normalizes on this). Kept for continuity.
+      this.setDeviceProperty('DeviceMemory', deviceMemory * 1000);
+      // Raw navigator.deviceMemory (GB), unit encoded in the key name.
+      this.setDeviceProperty('DeviceMemoryGB', deviceMemory);
     }
 
     const screenHeight = getScreenHeight();
@@ -125,6 +134,38 @@ class C3D {
     if (gpuInfo) {
       this.setDeviceProperty('DeviceGPU', gpuInfo.renderer);
       this.setDeviceProperty('DeviceGPUVendor', gpuInfo.vendor);
+    }
+
+    // Raw device-identity signals for pipeline-side resolution (SDK does no classification).
+    // Booleans/numbers are gated on `!== null` so meaningful falsy values (false, 0) are still sent.
+    const userAgent = getUserAgent();
+    if (userAgent) {
+      this.setDeviceProperty('UserAgent', userAgent);
+    }
+
+    const uaBrands = getUABrands();
+    if (uaBrands) {
+      this.setDeviceProperty('UABrands', uaBrands);
+    }
+
+    const uaMobile = getUAMobile();
+    if (uaMobile !== null) {
+      this.setDeviceProperty('UAMobile', uaMobile);
+    }
+
+    const maxTouchPoints = getMaxTouchPoints();
+    if (maxTouchPoints !== null) {
+      this.setDeviceProperty('DeviceMaxTouchPoints', maxTouchPoints);
+    }
+
+    const pointerCoarse = getPointerCoarse();
+    if (pointerCoarse !== null) {
+      this.setDeviceProperty('DevicePointerCoarse', pointerCoarse);
+    }
+
+    const hoverHover = getHoverHover();
+    if (hoverHover !== null) {
+      this.setDeviceProperty('DeviceHoverHover', hoverHover);
     }
   }
 
@@ -251,21 +292,14 @@ class C3D {
     }
 
     if (xrSession && xrSession.inputSources) {
-        const hmdInfo = getHMDInfo(xrSession.inputSources);
-        if (hmdInfo) {
-            this.setDeviceProperty('VRModel', hmdInfo.VRModel);
-            this.setDeviceProperty('VRVendor', hmdInfo.VRVendor);
-        }
+        // Raw input profiles replace the removed classified c3d.device.hmd.type / c3d.device.vendor.
+        this.setDeviceProperty('XRInputProfiles', getInputProfiles(xrSession.inputSources));
 
         xrSession.addEventListener('inputsourceschange', (event: XRInputSourcesChangeEvent) => {
             // @ts-ignore
             const xrEvent = event as XRInputSourcesChangeEvent;
-            const newHmdInfo = getHMDInfo(xrEvent.session.inputSources);
             this.setSessionProperty('c3d.device.controllerinputs.enabled', hasTrackedControllers(xrEvent.session.inputSources));
-            if (newHmdInfo) {
-                this.setDeviceProperty('VRModel', newHmdInfo.VRModel);
-                this.setDeviceProperty('VRVendor', newHmdInfo.VRVendor);
-            }
+            this.setDeviceProperty('XRInputProfiles', getInputProfiles(xrEvent.session.inputSources));
         });
     }
 

--- a/src/utils/ControllerInputTracker.ts
+++ b/src/utils/ControllerInputTracker.ts
@@ -10,7 +10,7 @@ interface C3DInstance {
         registerControllerObject: (
             name: string, meshname: string, customid: string,
             position: number[], rotation: number[],
-            controllerType: string, handedness: 'left' | 'right'
+            inputProfiles: string[], handedness: 'left' | 'right'
         ) => string;
         addInputSnapshot: (
             id: string, position: number[], rotation: number[],
@@ -23,83 +23,47 @@ interface C3DInstance {
     lastInputType: 'none' | 'hand' | 'controller';
 }
 
-interface ControllerProfile {
-    mesh: (h: 'left' | 'right') => string;
-    controllerType: (h: 'left' | 'right') => string;
-}
+// Maps a raw WebXR profile id to the dashboard mesh used to render the controller.
+// This is rendering configuration only. Controller *identity* is carried by the raw
+// input profiles transmitted alongside (see registerControllerObject) and is never
+// classified in the SDK.
+type ControllerMesh = (h: 'left' | 'right') => string;
 
-const CONTROLLER_PROFILE_MAP: Record<string, ControllerProfile> = {
-    'meta-quest-touch-plus': {
-        mesh: h => h === 'left' ? 'QuestPlusTouchLeft' : 'QuestPlusTouchRight',
-        controllerType: h => h === 'left' ? 'quest_plus_touch_left' : 'quest_plus_touch_right',
-    },
-    'meta-quest-touch-pro': {
-        mesh: h => h === 'left' ? 'QuestProTouchLeft' : 'QuestProTouchRight',
-        controllerType: h => h === 'left' ? 'quest_pro_touch_left' : 'quest_pro_touch_right',
-    },
-    'oculus-touch-v3': {
-        mesh: h => h === 'left' ? 'OculusQuestTouchLeft' : 'OculusQuestTouchRight',
-        controllerType: h => h === 'left' ? 'oculus_quest_touch_left' : 'oculus_quest_touch_right',
-    },
-    'oculus-touch-v2': {
-        mesh: h => h === 'left' ? 'OculusQuestTouchLeft' : 'OculusQuestTouchRight',
-        controllerType: h => h === 'left' ? 'oculus_quest_touch_left' : 'oculus_quest_touch_right',
-    },
-    'oculus-touch': {
-        mesh: h => h === 'left' ? 'OculusRiftTouchLeft' : 'OculusRiftTouchRight',
-        controllerType: h => h === 'left' ? 'oculus_rift_controller_left' : 'oculus_rift_controller_right',
-    },
-    'htc-vive-focus-3': {
-        mesh: h => h === 'left' ? 'ViveFocusControllerLeft' : 'ViveFocusControllerRight',
-        controllerType: h => h === 'left' ? 'vive_focus_controller_left' : 'vive_focus_controller_right',
-    },
-    'htc-vive': {
-        mesh: _ => 'ViveController',
-        controllerType: _ => 'vive_controller',
-    },
-    'valve-index': {
-        mesh: h => h === 'left' ? 'SteamIndexLeft' : 'SteamIndexRight',
-        controllerType: h => h === 'left' ? 'steam_index_left' : 'steam_index_right',
-    },
-    'microsoft-mixed-reality': {
-        mesh: h => h === 'left' ? 'WindowsMixedRealityLeft' : 'WindowsMixedRealityRight',
-        controllerType: h => h === 'left' ? 'windows_mixed_reality_controller_left' : 'windows_mixed_reality_controller_right',
-    },
-    'hp-mixed-reality': {
-        mesh: h => h === 'left' ? 'WindowsMixedRealityLeft' : 'WindowsMixedRealityRight',
-        controllerType: h => h === 'left' ? 'windows_mixed_reality_controller_left' : 'windows_mixed_reality_controller_right',
-    },
-    'pico-neo3-controller': {
-        mesh: h => h === 'left' ? 'PicoNeo3ControllerLeft' : 'PicoNeo3ControllerRight',
-        controllerType: h => h === 'left' ? 'pico_neo_3_eye_controller_left' : 'pico_neo_3_eye_controller_right',
-    },
-    'pico-4-controller': {
-        mesh: h => h === 'left' ? 'PicoNeo4ControllerLeft' : 'PicoNeo4ControllerRight',
-        controllerType: h => h === 'left' ? 'pico_neo_4_eye_controller_left' : 'pico_neo_4_eye_controller_right',
-    },
+const CONTROLLER_MESH_MAP: Record<string, ControllerMesh> = {
+    'meta-quest-touch-plus': h => h === 'left' ? 'QuestPlusTouchLeft' : 'QuestPlusTouchRight',
+    'meta-quest-touch-pro': h => h === 'left' ? 'QuestProTouchLeft' : 'QuestProTouchRight',
+    'oculus-touch-v3': h => h === 'left' ? 'OculusQuestTouchLeft' : 'OculusQuestTouchRight',
+    'oculus-touch-v2': h => h === 'left' ? 'OculusQuestTouchLeft' : 'OculusQuestTouchRight',
+    'oculus-touch': h => h === 'left' ? 'OculusRiftTouchLeft' : 'OculusRiftTouchRight',
+    'htc-vive-focus-3': h => h === 'left' ? 'ViveFocusControllerLeft' : 'ViveFocusControllerRight',
+    'htc-vive': _ => 'ViveController',
+    'valve-index': h => h === 'left' ? 'SteamIndexLeft' : 'SteamIndexRight',
+    'microsoft-mixed-reality': h => h === 'left' ? 'WindowsMixedRealityLeft' : 'WindowsMixedRealityRight',
+    'hp-mixed-reality': h => h === 'left' ? 'WindowsMixedRealityLeft' : 'WindowsMixedRealityRight',
+    'pico-neo3-controller': h => h === 'left' ? 'PicoNeo3ControllerLeft' : 'PicoNeo3ControllerRight',
+    'pico-4-controller': h => h === 'left' ? 'PicoNeo4ControllerLeft' : 'PicoNeo4ControllerRight',
 };
 
-const UNKNOWN_PROFILE: ControllerProfile = {
-    mesh: _ => 'GenericController',
-    controllerType: h => h === 'left' ? 'unknown_controller_left' : 'unknown_controller_right',
-};
+const UNKNOWN_MESH: ControllerMesh = _ => 'GenericController';
 
-function resolveControllerProfile(profiles: readonly string[], fallback?: string): ControllerProfile {
+// Resolves the render mesh only. `fallbackController` selects a mesh for unrecognized
+// profiles; it does not influence any identity signal — the raw profiles are always sent.
+export function resolveControllerMesh(profiles: readonly string[], handedness: 'left' | 'right', fallback?: string): string {
     for (const profile of profiles) {
         const lower = profile.toLowerCase();
-        for (const key of Object.keys(CONTROLLER_PROFILE_MAP)) {
-            if (lower.includes(key)) return CONTROLLER_PROFILE_MAP[key];
+        for (const key of Object.keys(CONTROLLER_MESH_MAP)) {
+            if (lower.includes(key)) return CONTROLLER_MESH_MAP[key](handedness);
         }
     }
     if (fallback) {
-        const fallbackProfile = CONTROLLER_PROFILE_MAP[fallback];
-        if (fallbackProfile) {
-            console.warn(`C3D: Unrecognized controller profiles [${profiles.join(', ')}]. Using configured fallback '${fallback}'.`);
-            return fallbackProfile;
+        const fallbackMesh = CONTROLLER_MESH_MAP[fallback];
+        if (fallbackMesh) {
+            console.warn(`C3D: Unrecognized controller profiles [${profiles.join(', ')}]. Using configured fallback mesh '${fallback}'.`);
+            return fallbackMesh(handedness);
         }
     }
-    console.warn(`C3D: Unrecognized controller profiles [${profiles.join(', ')}]. Using generic unknown controller.`);
-    return UNKNOWN_PROFILE;
+    console.warn(`C3D: Unrecognized controller profiles [${profiles.join(', ')}]. Using generic controller mesh.`);
+    return UNKNOWN_MESH(handedness);
 }
 
 const ANALOG_THROTTLE_MS = 100;
@@ -206,14 +170,14 @@ class ControllerInputTracker {
             const id = handedness === 'left' ? 'c3d_controller_left' : 'c3d_controller_right';
 
             if (!this.registeredIds.has(id)) {
-                const profile = resolveControllerProfile(src.profiles, this.fallbackController);
+                const mesh = resolveControllerMesh(src.profiles, handedness, this.fallbackController);
                 const pose = frame.getPose(src.gripSpace, refSpace);
                 const pos = pose ? this._extractPos(pose) : [0, 0, 0];
                 const rot = pose ? this._extractRot(pose) : [0, 0, 0, 1];
                 const name = handedness === 'left' ? 'Left Controller' : 'Right Controller';
                 this.c3d.dynamicObject.registerControllerObject(
-                    name, profile.mesh(handedness), id, pos, rot,
-                    profile.controllerType(handedness), handedness
+                    name, mesh, id, pos, rot,
+                    Array.from(src.profiles), handedness
                 );
                 this.registeredIds.add(id);
                 this.lastPoses.set(id, { pos, rot });
@@ -316,9 +280,8 @@ class ControllerInputTracker {
 
             if (!this.registeredIds.has(id)) {
                 const meshname = handedness === 'left' ? 'handLeft' : 'handRight';
-                const ctType = handedness === 'left' ? 'hand_left' : 'hand_right';
                 const name = handedness === 'left' ? 'Left Hand' : 'Right Hand';
-                this.c3d.dynamicObject.registerControllerObject(name, meshname, id, pos, rot, ctType, handedness);
+                this.c3d.dynamicObject.registerControllerObject(name, meshname, id, pos, rot, Array.from(src.profiles ?? []), handedness);
                 this.registeredIds.add(id);
                 continue;
             }

--- a/src/utils/ControllerInputTracker.ts
+++ b/src/utils/ControllerInputTracker.ts
@@ -170,14 +170,18 @@ class ControllerInputTracker {
             const id = handedness === 'left' ? 'c3d_controller_left' : 'c3d_controller_right';
 
             if (!this.registeredIds.has(id)) {
-                const mesh = resolveControllerMesh(src.profiles, handedness, this.fallbackController);
+                // Guard src.profiles: per the WebXR spec it is always present, but polyfills and
+                // synthetic input sources can omit it. Match the defensiveness of getInputProfiles()
+                // and the hand path below so a malformed source can't throw and kill the frame loop.
+                const profiles = src.profiles ?? [];
+                const mesh = resolveControllerMesh(profiles, handedness, this.fallbackController);
                 const pose = frame.getPose(src.gripSpace, refSpace);
                 const pos = pose ? this._extractPos(pose) : [0, 0, 0];
                 const rot = pose ? this._extractRot(pose) : [0, 0, 0, 1];
                 const name = handedness === 'left' ? 'Left Controller' : 'Right Controller';
                 this.c3d.dynamicObject.registerControllerObject(
                     name, mesh, id, pos, rot,
-                    Array.from(src.profiles), handedness
+                    Array.from(profiles), handedness
                 );
                 this.registeredIds.add(id);
                 this.lastPoses.set(id, { pos, rot });

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,18 +1,8 @@
 import crossFetch from 'cross-fetch';
 
-interface UADataValues {
-    platform: string;
-    platformVersion: string;
-    architecture?: string;
-    model?: string;
-    uaFullVersion?: string;
-    [key: string]: string | undefined;
-}
-
 interface NavigatorUAData {
     mobile: boolean;
     brands: Array<{ brand: string; version: string }>;
-    getHighEntropyValues(_hints: string[]): Promise<UADataValues>;
 }
 
 interface ExtendedNavigator extends Navigator {
@@ -46,55 +36,20 @@ export const getUserAgent = (): string => safeWindowAccess(() => navigator.userA
 export const getHardwareConcurrency = (): number | null => safeWindowAccess(() => navigator.hardwareConcurrency, null);
 export const getConnection = (): ExtendedNavigator['connection'] | null => safeWindowAccess(() => (navigator as ExtendedNavigator).connection ?? null, null);
 
-interface SystemInfo { os: string; deviceType: string; browser: string; }
+// Raw User-Agent Client Hints (low-entropy, no permission prompt). Sent verbatim so the
+// pipeline — not the SDK — resolves browser/OS/device from them.
+export const getUABrands = (): Array<{ brand: string; version: string }> | null =>
+    safeWindowAccess(() => (navigator as ExtendedNavigator).userAgentData?.brands ?? null, null);
+export const getUAMobile = (): boolean | null =>
+    safeWindowAccess(() => (navigator as ExtendedNavigator).userAgentData?.mobile ?? null, null);
 
-const _parseFromUserAgent = (userAgent: string): SystemInfo => {
-    const osMap = [
-        { name: 'Windows', regex: /Windows/ },
-        { name: 'macOS', regex: /Macintosh|MacIntel|MacPPC|Mac68K/ },
-        { name: 'Android', regex: /Android/ },
-        { name: 'iOS', regex: /iPhone|iPad|iPod/ },
-        { name: 'Linux', regex: /Linux/ },
-    ];
-    const browserMap = [
-        { name: 'Firefox', regex: /Firefox/i },
-        { name: 'Opera', regex: /OPR|Opera/i },
-        { name: 'Edge', regex: /Edg/i },
-        { name: 'Chrome', regex: /Chrome/i },
-        { name: 'Safari', regex: /Safari/i },
-    ];
-    const findMatch = (map: { name: string; regex: RegExp }[], agent: string) => 
-        map.find(entry => entry.regex.test(agent))?.name || 'unknown';
-
-    const os = findMatch(osMap, userAgent);
-    const browser = findMatch(browserMap, userAgent);
-    let deviceType = 'Desktop';
-    if (/Mobi|Android|iPhone/.test(userAgent)) deviceType = 'Mobile';
-    else if (/iPad/.test(userAgent)) deviceType = 'Tablet';
-
-    return { os, deviceType, browser };
-};
-
-const _parseFromUserAgentData = async (userAgentData: NavigatorUAData): Promise<SystemInfo> => {
-    const platformData = await userAgentData.getHighEntropyValues(['platform']);
-    const os = platformData.platform || 'unknown';
-    const deviceType = userAgentData.mobile ? 'Mobile' : 'Desktop';
-    const browserMap = [
-        { name: 'Opera', brand: 'Opera' },
-        { name: 'Edge', brand: 'Microsoft Edge' },
-        { name: 'Chrome', brand: 'Google Chrome' },
-    ];
-    const brandInfo = userAgentData.brands?.find(b => browserMap.some(bm => bm.brand === b.brand));
-    const browser = browserMap.find(bm => bm.brand === brandInfo?.brand)?.name || 'unknown';
-    return { os, deviceType, browser };
-};
-
-export const getSystemInfo = async (): Promise<SystemInfo> => {
-    if (!isBrowser) return { os: 'unknown', deviceType: 'unknown', browser: "unknown" };
-    const nav = navigator as ExtendedNavigator;
-    if (nav.userAgentData) return _parseFromUserAgentData(nav.userAgentData);
-    return _parseFromUserAgent(navigator.userAgent);
-};
+// Raw touch/pointer capability signals for phone/tablet/desktop disambiguation downstream.
+export const getMaxTouchPoints = (): number | null =>
+    safeWindowAccess(() => navigator.maxTouchPoints ?? null, null);
+export const getPointerCoarse = (): boolean | null =>
+    safeWindowAccess(() => window.matchMedia('(pointer: coarse)').matches, null);
+export const getHoverHover = (): boolean | null =>
+    safeWindowAccess(() => window.matchMedia('(hover: hover)').matches, null);
 
 export interface GPUInfo { vendor: string; renderer: string; }
 
@@ -108,10 +63,9 @@ export const getGPUInfo = (): GPUInfo | null => {
         const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
         if (!debugInfo) return null;
 
-        let vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
-        let renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
-        if (renderer?.toLowerCase().includes("adreno")) vendor = "Qualcomm";
-        
+        const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
+        const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+
         return { vendor, renderer };
     } catch (e) {
         console.warn("WebGL is not supported", e);

--- a/src/utils/webxr.ts
+++ b/src/utils/webxr.ts
@@ -206,33 +206,18 @@ export const hasTrackedControllers = (inputSources: XRInputSourceArray | XRInput
     return false;
 };
 
-// Controller (profile identifier) lookup table to infer HMD Device, note that headset can be different from controller brand 
-const HMD_PROFILE_MAP: { [key: string]: { VRModel: string; VRVendor: string } } = {
-    'meta-quest-touch-pro': { VRModel: 'Quest Pro', VRVendor: 'Meta' },
-    'meta-quest-touch-plus': { VRModel: 'Quest 3/ Quest 3S', VRVendor: 'Meta' },
-    'oculus-touch-v3': { VRModel: 'Quest 2', VRVendor: 'Meta' },
-    'oculus-touch': { VRModel: 'Quest/Rift S', VRVendor: 'Meta' }, // Generic fallback
-    'htc-vive': { VRModel: 'Vive', VRVendor: 'HTC' },
-    'valve-index': { VRModel: 'Index', VRVendor: 'Valve' },
-    'microsoft-mixed-reality': { VRModel: 'Mixed Reality', VRVendor: 'Microsoft' }
-};
-
-export const getHMDInfo = (inputSources: XRInputSourceArray | XRInputSource[]): { VRModel: string; VRVendor: string } | null => {
+// Raw WebXR input profiles (e.g. "meta-quest-touch-plus") flattened and de-duplicated
+// across all input sources. Returned verbatim as the device's hardware fingerprint — the
+// pipeline (not the SDK) resolves HMD/controller identity from these strings.
+export const getInputProfiles = (inputSources: XRInputSourceArray | XRInputSource[]): string[] => {
+    const profiles = new Set<string>();
     for (const source of inputSources) {
         if (!source.profiles) continue;
-
         for (const profile of source.profiles) {
-            const lowerCaseProfile = profile.toLowerCase();
-            
-            const matchedProfile = Object.keys(HMD_PROFILE_MAP).find(key => lowerCaseProfile.includes(key));
-
-            if (matchedProfile) {
-                console.log("HMD Profile Matched: ", lowerCaseProfile);
-                return HMD_PROFILE_MAP[matchedProfile];
-            }
+            profiles.add(profile);
         }
     }
-    return null; 
+    return Array.from(profiles);
 };
 
 export const getEnabledFeatures = (xrSession: XRSession): { handTracking: boolean; eyeTracking: boolean } => {


### PR DESCRIPTION
## What

Makes the WebXR SDK emit **raw** device signals and removes all in-SDK device
classification, so downstream systems (not the SDK) resolve device type/identity.

## Removed in-SDK classification

- `HMD_PROFILE_MAP` + `getHMDInfo()` → raw `XRInputSource.profiles` sent verbatim as
  `c3d.device.xr.input_profiles`. Removed the ambiguous classified keys
  `c3d.device.hmd.type` / `c3d.device.vendor` (e.g. `"Quest 3/ Quest 3S"`).
- Classified `controllerType` on the dynamic-object manifest → raw `inputProfiles[]`. The
  controller **mesh** map (rendering config) is kept; `fallbackController` now selects only
  the render mesh.
- GPU vendor `"Qualcomm"` override → raw `UNMASKED_VENDOR_WEBGL` string.
- Dead UA-classification (`getSystemInfo` / `_parseFromUserAgent*`) deleted.
- `hmdtype` gaze-payload shadow channel removed.

## Added raw signals (verbatim, no classification)

`c3d.device.user_agent`, `ua_brands`, `ua_mobile`, `max_touch_points`, `pointer_coarse`,
`hover_hover`, `memoryInGB` (raw GB — the legacy MB `c3d.device.memory` is intentionally
unchanged), and `c3d.device.xr.input_profiles`.

## Deprecations (kept, not removed)

`GazeTracker.setHMDType()` and the `HMDType` config setting are retained as **loud no-ops**
(`console.warn` on use). These are public API surface, so they warn rather than break
callers; the SDK never used them internally.

## Tests

New `device-signals` and `controller-mesh` suites; updated the `mobile-ar` assertion; wired
`@babel/preset-typescript` into the jest env so source helpers can be unit-tested. Build and
all hermetic suites pass. (Network-dependent suites require `C3D_APPLICATION_KEY`, provided
in CI.)

## Follow-ups (not in this PR)

- `c3d.device.memoryInGB` ships correctly named but stays inert until the downstream
  pipeline reads it — separate pipeline-side work.
- Downstream rule-table wiring to consume `c3d.device.xr.input_profiles` (and the new
  memory/touch signals) is separate cross-repo work.
- The `c3d.sdk.version` vs `c3d.version` key mismatch is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7n2ie4kYznuRSjGHjiJ4Y
