### PR TITLE
Default c3d.app.engine for adapter-less core usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ It supports a wide range of development environments by providing multiple modul
 * **ES Module**: Modern module standard, used by most bundlers and modern Node.js.
 * **CommonJS**: Compatible with older Node.js environments.
 
+### Using the core SDK without an engine adapter
+
+When you use an engine adapter (Three.js, Babylon.js, PlayCanvas, Wonderland), the adapter sets `c3d.app.engine` for you. If you use the **core SDK directly with no adapter** (plain WebXR/WebGL), the SDK now defaults `c3d.app.engine` to `"WebXR"` so your sessions are accepted by the analytics pipeline — its enrichment layer treats `c3d.app.engine` as a required property and drops sessions that omit it.
+
+As belt-and-suspenders, you can also set it yourself to better identify your integration (this overrides the default):
+
+```js
+c3d.setDeviceProperty('AppEngine', 'YourEngineName');
+c3d.setDeviceProperty('AppEngineVersion', '1.0.0');
+```
+
 ## 📚 Documentation 
 The **[Cognitive3D WebXR SDK documentation](http://docs.cognitive3d.com/webxr/get-started/)** explains how to integrate the SDK, track user experiences, export scenes, track dynamic objects, and more.
 

--- a/__tests__/app-engine-default-test.js
+++ b/__tests__/app-engine-default-test.js
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Adapter-less ("plain core") usage must still carry c3d.app.engine (and c3d.sdk.type) so the
+ * pipeline's enrichment layer — which treats c3d.app.engine as a required core prop — does not
+ * drop the session. Engine adapters overwrite c3d.app.engine in their startTracking(); this
+ * verifies the core-provided default when no adapter is used.
+ */
+import C3DAnalytics from '../lib/cjs/index.cjs.js';
+
+const settings = {
+    config: {
+        APIKey: 'test-api-key',
+        networkHost: 'data.cognitive3d.com',
+        allSceneData: [
+            {
+                sceneName: 'BasicScene',
+                sceneId: '93f486e4-0e22-4650-946a-e64ce527f915',
+                versionNumber: '1',
+            },
+        ],
+    },
+};
+
+test('core sets a default c3d.app.engine and c3d.sdk.type for adapter-less usage', () => {
+    const c3d = new C3DAnalytics(settings);
+    expect(c3d.core.sessionProperties['c3d.app.engine']).toBe('WebXR');
+    expect(c3d.core.sessionProperties['c3d.sdk.type']).toBe('WebXR');
+});
+
+test('an engine adapter value overrides the default c3d.app.engine', () => {
+    const c3d = new C3DAnalytics(settings);
+    // Adapters call setDeviceProperty('AppEngine', ...) in startTracking() — simulate that here.
+    c3d.setDeviceProperty('AppEngine', 'Three.js');
+    expect(c3d.core.sessionProperties['c3d.app.engine']).toBe('Three.js');
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,16 @@ class C3D {
     this.xrSessionManager = null; 
     this._gazeRaycaster = null;
 
-    this.setUserProperty("c3d.version", this.core.config.SDKVersion);  
+    this.setUserProperty("c3d.version", this.core.config.SDKVersion);
     this.lastInputType = 'none';
+
+    // Identify the SDK, and default the engine for adapter-less ("plain core") usage.
+    // Engine adapters (Three.js / Babylon / PlayCanvas / Wonderland) overwrite c3d.app.engine
+    // via setDeviceProperty in their startTracking(), so this default only persists when no
+    // adapter is used. The pipeline's enrichment layer treats c3d.app.engine as a required
+    // core prop and drops sessions that omit it, so adapter-less sessions need a default here.
+    this.setDeviceProperty('SDKType', 'WebXR');
+    this.setDeviceProperty('AppEngine', 'WebXR');
     
     // Explicitly cast to unknown first to avoid circular type issues if strictly typed in deps
     const self = this as unknown as any; 


### PR DESCRIPTION
Recreates #142 (auto-closed when its base branch `raw-device-signals` was deleted on the #140 merge). Same content; now targets `development`. See SDK-541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7n2ie4kYznuRSjGHjiJ4Y