### PR TITLE
CI: pin npm to 11.x so publish works on Node 20

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       
       - name: Ensure npm 11.5.1 or later
-        run: npm install -g npm@latest
+        # Pin to the 11.x line: npm@latest is now 12.x, which requires Node >=22 and
+        # fails on this workflow's Node 20 runner (EBADENGINE). 11.x satisfies the
+        # ">=11.5.1" requirement and stays Node-20 compatible.
+        run: npm install -g npm@11
       
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
The publish workflow's "Ensure npm 11.5.1 or later" step runs `npm install -g npm@latest`, which now resolves to **npm@12** — which dropped Node 20 support (requires Node >=22.22.2). On this workflow's Node 20 runner it fails with `EBADENGINE`, breaking the publish job on every push to `development`/`main` (the #140 merge failed at this step, before tests/publish ran).

Fix: pin `npm@11` — satisfies the ">=11.5.1" requirement and stays Node-20 compatible. Alternative would be bumping the runner to Node 22; pinning npm is the minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7n2ie4kYznuRSjGHjiJ4Y