### PR TITLE
validation-app: participant name = experience + environment (e.g. "VR — macOS · Chrome")

### DIFF
--- a/examples/validation-app/README.md
+++ b/examples/validation-app/README.md
@@ -100,6 +100,10 @@ signal panel), and render a fixed status/signal panel that stays visible after
 exiting VR/AR, so you can read the results in the headset browser itself or
 after taking the headset off.
 
+Each session's **participant name** is set to `{experience} — {OS · browser}`
+(e.g. `VR — macOS · Chrome`) so session types are easy to scan in the dashboard's
+Participant column — no dev/prod in the name (the dashboard already scopes by env).
+
 ## Ending an immersive session
 
 Ending an immersive session always ends the Cognitive3D session and sends the

--- a/examples/validation-app/immersive-ar.html
+++ b/examples/validation-app/immersive-ar.html
@@ -205,7 +205,7 @@
           session.requestAnimationFrame(onXRFrame);
 
           statusEl.textContent = 'Session active. Starting Cognitive3D SDK session...';
-          await window.C3DValidation.init({ xrSession: session });
+          await window.C3DValidation.init({ xrSession: session, experience: 'AR' });
           statusEl.textContent =
             'Session active — Cognitive3D SDK session started. To end it: pull the controller ' +
             'trigger, tap the "Exit AR" button shown over the view, or use your headset\'s ' +

--- a/examples/validation-app/immersive-vr.html
+++ b/examples/validation-app/immersive-vr.html
@@ -184,7 +184,7 @@
           session.requestAnimationFrame(onXRFrame);
 
           statusEl.textContent = 'Session active. Starting Cognitive3D SDK session...';
-          await window.C3DValidation.init({ xrSession: session });
+          await window.C3DValidation.init({ xrSession: session, experience: 'VR' });
           statusEl.textContent =
             'Session active — Cognitive3D SDK session started. To end it: pull the controller ' +
             'trigger, use your headset\'s system menu, or (on desktop) the "Exit VR" button. ' +

--- a/examples/validation-app/index.html
+++ b/examples/validation-app/index.html
@@ -61,6 +61,11 @@
     <a href="https://app.cognitive3d.com/v3/projects/5163/projectsessions/all"
        target="_blank" rel="noopener">prod</a>
   </p>
+  <p class="note">
+    Each session's <b>participant name</b> is set to its type + environment (e.g.
+    <code>VR — macOS · Chrome</code>), so you can scan session types at a glance in the
+    dashboard's Participant column.
+  </p>
 
   <h2>No headset? Test with the Immersive Web Emulator</h2>
   <p class="note">

--- a/examples/validation-app/inline.html
+++ b/examples/validation-app/inline.html
@@ -90,7 +90,7 @@
         startBtn.disabled = true;
         statusEl.textContent = 'Starting session...';
         try {
-          await window.C3DValidation.init({ xrSession: null });
+          await window.C3DValidation.init({ xrSession: null, experience: '2D' });
           statusEl.textContent = 'Session start requested — see the status badge in the overlay.';
           refreshBtn.disabled = false;
           endBtn.disabled = false;

--- a/examples/validation-app/shared/cognitive3d-init.js
+++ b/examples/validation-app/shared/cognitive3d-init.js
@@ -84,6 +84,41 @@
            ' &nbsp;&middot;&nbsp; ' + getSeeSessionsHtml();
   }
 
+  // Human-readable "OS · Browser" label for the running environment (e.g. "macOS · Chrome",
+  // "Android · Quest Browser"). Used only to build a scannable participant name — this is a
+  // display label, NOT a device signal (the SDK sends raw signals for the pipeline to classify).
+  function getEnvironmentLabel() {
+    var ua = navigator.userAgent || '';
+    var os = 'Unknown OS';
+    if (/Windows NT/.test(ua)) os = 'Windows';
+    else if (/iPhone|iPad|iPod/.test(ua)) os = 'iOS';
+    else if (/Mac OS X/.test(ua)) os = 'macOS';
+    else if (/CrOS/.test(ua)) os = 'ChromeOS';
+    else if (/Android/.test(ua)) os = 'Android';
+    else if (/Linux/.test(ua)) os = 'Linux';
+
+    var browser = 'Unknown Browser';
+    if (/OculusBrowser/.test(ua)) browser = 'Quest Browser';
+    else if (/Edg\//.test(ua)) browser = 'Edge';
+    else if (/SamsungBrowser/.test(ua)) browser = 'Samsung Internet';
+    else if (/OPR\//.test(ua)) browser = 'Opera';
+    else if (/Firefox\//.test(ua)) browser = 'Firefox';
+    else if (/Chrome\//.test(ua)) browser = 'Chrome';
+    else if (/Safari\//.test(ua)) browser = 'Safari';
+
+    return os + ' · ' + browser;
+  }
+
+  // Short experience tag for the participant name. Prefers the caller's explicit hint
+  // ('2D' | 'VR' | 'AR'); falls back to the XRSession mode, then to 2D/XR.
+  function getExperienceLabel(experience, xrSession) {
+    if (experience === '2D' || experience === 'VR' || experience === 'AR') return experience;
+    var mode = xrSession && xrSession.mode;
+    if (mode === 'immersive-vr') return 'VR';
+    if (mode === 'immersive-ar') return 'AR';
+    return xrSession ? 'XR' : '2D';
+  }
+
   var UNHANDLED_REJECTION_FLAG = '__c3dValidationUnhandledRejectionHooked';
 
   /**
@@ -126,7 +161,7 @@
    * and the overlay should render them regardless of whether the session
    * made it to the server.
    *
-   * @param {{ xrSession?: XRSession | null }} [options]
+   * @param {{ xrSession?: XRSession | null, experience?: '2D' | 'VR' | 'AR' }} [options]
    * @returns {Promise<InstanceType<typeof window.C3D>>}
    */
   async function init(options) {
@@ -174,6 +209,12 @@
       c3d.setDeviceProperty('AppName', 'C3D WebXR Validation App');
       c3d.setDeviceProperty('AppEngine', 'WebXR');
       c3d.setDeviceProperty('AppEngineVersion', (c3d.core && c3d.core.config && c3d.core.config.SDKVersion) || 'unknown');
+      // Participant name = experience + environment, e.g. "VR — macOS · Chrome", so session
+      // types are easy to scan in the dashboard's Participant column. Deliberately NO dev/prod —
+      // the dashboard already scopes by environment, so it would be redundant.
+      c3d.setParticipantFullName(
+        getExperienceLabel(options && options.experience, xrSession) + ' — ' + getEnvironmentLabel()
+      );
       await c3d.startSession(xrSession);
     } catch (err) {
       console.error(


### PR DESCRIPTION
Sets each validation session's **participant name** to its experience + environment so session types are easy to scan in the Cognitive3D dashboard's Participant column.

## What
- Participant name (`c3d.name`, via the SDK's `setParticipantFullName`) = `"{2D|VR|AR} — {OS · browser}"`, e.g. **`VR — macOS · Chrome`**, **`2D — Windows · Edge`**, **`AR — Android · Quest Browser`**.
- Each page passes its experience (`'2D'` / `'VR'` / `'AR'`) to `C3DValidation.init()`.
- `shared/cognitive3d-init.js` derives a small `OS · browser` label from the user agent (**display-only — not a device signal**; the SDK still sends raw signals for the pipeline to classify) and sets the name before `startSession`.
- **No dev/prod in the name** — the dashboard already scopes by environment, so it'd be redundant (per the ask).

## Verified (Playwright, real SDK, dev backend)
- 2D → `2D — macOS · Chrome`, VR → `VR — macOS · Chrome`, AR → `AR — macOS · Chrome` (both `c3d.name` and userId set).

examples/ only; no `src/` (published SDK) change. README + landing page note the naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7n2ie4kYznuRSjGHjiJ4Y