### PR TITLE
validation-app: also set session name so the dashboard list is labeled by type

### DIFF
--- a/examples/validation-app/README.md
+++ b/examples/validation-app/README.md
@@ -100,9 +100,9 @@ signal panel), and render a fixed status/signal panel that stays visible after
 exiting VR/AR, so you can read the results in the headset browser itself or
 after taking the headset off.
 
-Each session's **participant name** is set to `{experience} — {OS · browser}`
+Each session's **name** (and participant name) is set to `{experience} — {OS · browser}`
 (e.g. `VR — macOS · Chrome`) so session types are easy to scan in the dashboard's
-Participant column — no dev/prod in the name (the dashboard already scopes by env).
+session list — no dev/prod in the name (the dashboard already scopes by env).
 
 ## Ending an immersive session
 

--- a/examples/validation-app/index.html
+++ b/examples/validation-app/index.html
@@ -62,9 +62,9 @@
        target="_blank" rel="noopener">prod</a>
   </p>
   <p class="note">
-    Each session's <b>participant name</b> is set to its type + environment (e.g.
+    Each session's <b>name</b> is set to its type + environment (e.g.
     <code>VR — macOS · Chrome</code>), so you can scan session types at a glance in the
-    dashboard's Participant column.
+    dashboard's session list.
   </p>
 
   <h2>No headset? Test with the Immersive Web Emulator</h2>

--- a/examples/validation-app/shared/cognitive3d-init.js
+++ b/examples/validation-app/shared/cognitive3d-init.js
@@ -209,12 +209,15 @@
       c3d.setDeviceProperty('AppName', 'C3D WebXR Validation App');
       c3d.setDeviceProperty('AppEngine', 'WebXR');
       c3d.setDeviceProperty('AppEngineVersion', (c3d.core && c3d.core.config && c3d.core.config.SDKVersion) || 'unknown');
-      // Participant name = experience + environment, e.g. "VR — macOS · Chrome", so session
-      // types are easy to scan in the dashboard's Participant column. Deliberately NO dev/prod —
-      // the dashboard already scopes by environment, so it would be redundant.
-      c3d.setParticipantFullName(
-        getExperienceLabel(options && options.experience, xrSession) + ' — ' + getEnvironmentLabel()
-      );
+      // Label each session by experience + environment, e.g. "VR — macOS · Chrome", so session
+      // types are easy to scan in the dashboard. Set BOTH:
+      //  - the session name (c3d.sessionname) — the bold per-session label in the session list;
+      //    without it the backend auto-generates a random "Adjective Color Animal from City" name;
+      //  - the participant name (c3d.name) — shown in the Participant view/filter.
+      // Deliberately NO dev/prod in the label — the dashboard already scopes by environment.
+      var sessionLabel = getExperienceLabel(options && options.experience, xrSession) + ' — ' + getEnvironmentLabel();
+      c3d.setSessionName(sessionLabel);
+      c3d.setParticipantFullName(sessionLabel);
       await c3d.startSession(xrSession);
     } catch (err) {
       console.error(


### PR DESCRIPTION
Follow-up to #149. The participant name (`c3d.name`) was landing, but the **dashboard session-list label is the *session* name (`c3d.sessionname`)**, which was unset — so the backend auto-generated random names like *"Existing Pearl Kakapo from Portland"* (the "…from Portland" is the geo city).

## Fix
Set **both** to the same `"{2D|VR|AR} — {OS · browser}"` label:
- `c3d.sessionname` via `setSessionName()` — the bold per-session label in the session list (**the fix**);
- `c3d.name` via `setParticipantFullName()` — the Participant view/filter (unchanged).

Verified in-browser: both land, e.g. `2D — macOS · Chrome`. examples/ only; no `src/` change. README + landing page notes updated.