### PR TITLE
Add validate-c3d-session skill (client-facing session-landed check)

### DIFF
--- a/.claude/skills/validate-c3d-session/SKILL.md
+++ b/.claude/skills/validate-c3d-session/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: validate-c3d-session
+description: >-
+  Verify that session data from a Cognitive3D SDK integration (WebXR, Unity, Unreal, or any
+  host/client) has landed on the Cognitive3D backend for a given project, and report a few
+  top-level details of the most recent session(s) — duration, session name, participant,
+  which data types were captured (gaze/events/sensors/dynamics/fixations), app/SDK/device,
+  and test/junk tags. Use when someone asks to confirm sessions are arriving, validate an SDK
+  integration end-to-end, check that a test session landed, or troubleshoot "is my data
+  reaching Cognitive3D?". Requires an organization API key (the org ID is derived from it) and
+  a project ID.
+---
+
+<!-- markdownlint-disable MD013 -->
+
+# Validate a Cognitive3D session landed
+
+Confirms that sessions from your app are reaching the Cognitive3D platform and shows a few
+top-level details of the most recent one(s). It only **reads** the backend REST API — it does
+not send or modify anything — so it is safe to run against any project, including production.
+
+## When to use
+
+- After wiring up a Cognitive3D SDK, to confirm sessions actually arrive (not just HTTP 200 at
+  send time — this checks the queryable backend).
+- To spot-check that a specific recent/test session landed and looks reasonable.
+- To troubleshoot "my dashboard is empty / is my data reaching Cognitive3D?".
+
+## What you need
+
+1. **Organization API key** — Cognitive3D dashboard → **Organization Settings → API Keys**.
+   Format `orgkey-…` (a raw key is also accepted; the script adds the prefix). This is an
+   *organization* key (read access to the REST API), **not** the application/DATA key the SDK
+   uses to *send* data. There is a separate key per environment (dev vs. prod).
+   The organization ID is derived from the key automatically — you do not supply it.
+2. **Project ID** (integer) — required, because an organization can hold several projects.
+   Find it in the dashboard project URL (e.g. `.../projects/1234/...`).
+3. **Environment** — `prod` (default → `api.cognitive3d.com`) or `dev` (→ `api.c3ddev.com`).
+   Must match the key's environment.
+
+## Keep the key out of your shell history
+
+Pass the key via an environment variable (never as a command argument, so it does not leak into
+history or the process list). The script also accepts it via a hidden interactive prompt, and
+sends it to `curl` through a mode-600 config file — it is never printed.
+
+## How to run
+
+```bash
+export C3D_ORG_API_KEY='orgkey-xxxxxxxxxxxx'
+.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh --project 1234
+```
+
+Options:
+
+| Flag | Meaning |
+| --- | --- |
+| `--project <id>` | **Required.** Numeric project ID. |
+| `--env <prod\|dev>` | API host / environment. Default `prod`. |
+| `--limit <n>` | How many recent sessions to show. Default `5`. |
+| `--session <id>` | Only report this specific SDK session id. |
+| `--within <minutes>` | Warn (exit 4) if the newest session is older than this — handy right after a test run. |
+
+Exit codes: `0` sessions found · `3` none found · `1` auth/other error · `4` newest older than `--within`.
+
+## What it does
+
+1. `GET /v0/organizations/apiKeys/whoami` → validates auth and derives the **organization ID**.
+2. `POST /v0/datasets/sessions/paginatedListQueries` with `sessionType: "project"` and the
+   project ID → the most recent sessions (newest first).
+3. Prints **PASS/FAIL** (did anything land?) plus, per session: id, when it landed (+ age),
+   duration, session name, participant, which data types were captured, app/SDK/device, and
+   test/junk tags.
+
+## Example output
+
+```text
+Cognitive3D session check
+  organization : 4365   (derived from the API key)
+  project      : 5163
+  environment  : prod  (api.cognitive3d.com)
+
+✅ 25 session(s) exist for this project; showing the 3 most recent — data is landing on the platform.
+
+── 1783716564_ab12cd…
+     landed      2026-07-10T20:49:24.000Z   (~6 min ago)
+     duration    30 s
+     name        AR — macOS · Chrome
+     participant AR — macOS · Chrome
+     captured    gaze=yes events=yes sensors=yes dynamics=no fixations=no
+     app / sdk   My WebXR App  ·  engine=WebXR  ·  sdk=2.9.0
+     device      Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 …
+     tags        test=false  junk=false
+```
+
+## Manual fallback (no script)
+
+If you'd rather run the calls yourself, the two requests are:
+
+```bash
+# 1) auth + org id
+curl -fsS -H "Authorization: orgkey-$KEY" https://api.cognitive3d.com/v0/organizations/apiKeys/whoami
+
+# 2) recent project sessions
+curl -sS -H "Authorization: orgkey-$KEY" -H "Content-Type: application/json" \
+  -X POST https://api.cognitive3d.com/v0/datasets/sessions/paginatedListQueries \
+  -d '{"sessionType":"project","entityFilters":{"projectId":1234},"page":0,"limit":5,"sort":"desc","orderBy":{"fieldName":"date","fieldParent":"session"}}'
+```
+
+(For dev, use `api.c3ddev.com`.) `sessionType: "project"` is required — omitting it defaults to
+*scene* sessions, which additionally require a `versionId`.
+
+## Notes
+
+- **"Landed" vs. "queryable"**: the SDK sending data returns HTTP 200 at ingest, but a session
+  only becomes queryable after the pipeline accepts it. If sends succeed yet nothing appears
+  here, the pipeline may be dropping the session (e.g. a required core property is missing).
+- **`junk=true`** is auto-applied by the pipeline when a session records no HMD/head movement;
+  such sessions are excluded from many default analytics views but still appear here.
+- **`test=true`** sessions are typically excluded from analytics by default.

--- a/.claude/skills/validate-c3d-session/SKILL.md
+++ b/.claude/skills/validate-c3d-session/SKILL.md
@@ -7,8 +7,8 @@ description: >-
   which data types were captured (gaze/events/sensors/dynamics/fixations), app/SDK/device,
   and test/junk tags. Use when someone asks to confirm sessions are arriving, validate an SDK
   integration end-to-end, check that a test session landed, or troubleshoot "is my data
-  reaching Cognitive3D?". Requires an organization API key (the org ID is derived from it) and
-  a project ID.
+  reaching Cognitive3D?". Requires an organization API key (the org ID is derived from it); the
+  project ID is optional and auto-selected when the organization has a single project.
 ---
 
 <!-- markdownlint-disable MD013 -->
@@ -33,8 +33,9 @@ not send or modify anything — so it is safe to run against any project, includ
    *organization* key (read access to the REST API), **not** the application/DATA key the SDK
    uses to *send* data. There is a separate key per environment (dev vs. prod).
    The organization ID is derived from the key automatically — you do not supply it.
-2. **Project ID** (integer) — required, because an organization can hold several projects.
-   Find it in the dashboard project URL (e.g. `.../projects/1234/...`).
+2. **Project ID** (integer) — the project to check. **Optional if the organization has exactly one
+   project** (it is auto-selected); required when there are several. Find it in the dashboard
+   project URL (e.g. `.../projects/1234/...`).
 3. **Environment** — `prod` (default → `api.cognitive3d.com`) or `dev` (→ `api.c3ddev.com`).
    Must match the key's environment.
 
@@ -55,7 +56,7 @@ Options:
 
 | Flag | Meaning |
 | --- | --- |
-| `--project <id>` | **Required.** Numeric project ID. |
+| `--project <id>` | Numeric project ID. Optional if the org has exactly one project (auto-selected); required otherwise. |
 | `--env <prod\|dev>` | API host / environment. Default `prod`. |
 | `--limit <n>` | How many recent sessions to show. Default `5`. |
 | `--session <id>` | Only report this specific SDK session id. |

--- a/.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh
+++ b/.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh
@@ -7,8 +7,9 @@
 # Works for any SDK/host (WebXR, Unity, Unreal, ...) — it only reads the backend.
 #
 # Auth: an ORGANIZATION API key (dashboard -> Organization Settings -> API Keys).
-# The organization ID is derived from the key automatically. A project ID is
-# required because an organization can contain multiple projects.
+# The organization ID is derived from the key automatically. A project ID scopes
+# the check; it is optional if the organization has exactly one project (then it
+# is auto-selected), and required when the organization has several.
 #
 # The key is read from the C3D_ORG_API_KEY environment variable (preferred, so it
 # never appears in your shell history or the process list) or prompted for with
@@ -16,7 +17,7 @@
 #
 # Usage:
 #   export C3D_ORG_API_KEY='orgkey-xxxxxxxxxxxx'
-#   ./validate-c3d-session.sh --project 1234 [--env prod|dev] [--limit 5] [--session <id>] [--within <minutes>]
+#   ./validate-c3d-session.sh [--project 1234] [--env prod|dev] [--limit 5] [--session <id>] [--within <minutes>]
 #
 # Requires: bash, curl, jq.
 #
@@ -47,9 +48,10 @@ done
 command -v curl >/dev/null || { echo "error: curl is required" >&2; exit 1; }
 command -v jq   >/dev/null || { echo "error: jq is required (https://jqlang.github.io/jq/)" >&2; exit 1; }
 
-[ -n "$PROJECT" ] || { echo "error: --project <id> is required" >&2; usage; exit 2; }
-case "$PROJECT" in ''|*[!0-9]*) echo "error: --project must be numeric" >&2; exit 2;; esac
-case "$LIMIT"   in ''|*[!0-9]*) echo "error: --limit must be numeric" >&2; exit 2;; esac
+if [ -n "$PROJECT" ]; then
+  case "$PROJECT" in *[!0-9]*) echo "error: --project must be numeric" >&2; exit 2;; esac
+fi
+case "$LIMIT" in ''|*[!0-9]*) echo "error: --limit must be numeric" >&2; exit 2;; esac
 
 case "$ENVIRONMENT" in
   prod) BASE="https://api.cognitive3d.com";;
@@ -78,6 +80,24 @@ ORG_ID="$(api_get /v0/organizations/apiKeys/whoami 2>/dev/null | jq -r '.organiz
 if [ -z "$ORG_ID" ]; then
   echo "❌ Auth failed against ${BASE#https://}. Check the key is correct and that --env matches the key's environment (a prod key won't work on dev, or vice-versa)." >&2
   exit 1
+fi
+
+# ---- 1b. resolve project: auto-select when the organization has exactly one ----
+if [ -z "$PROJECT" ]; then
+  ORG_JSON="$(api_get "/v0/organizations/$ORG_ID" 2>/dev/null || true)"
+  PCOUNT="$(printf '%s' "$ORG_JSON" | jq -r '(.projects // []) | length' 2>/dev/null || echo 0)"
+  if [ "${PCOUNT:-0}" -eq 1 ]; then
+    PROJECT="$(printf '%s' "$ORG_JSON" | jq -r '.projects[0].id')"
+    PNAME="$(printf '%s' "$ORG_JSON" | jq -r '.projects[0].name // ""')"
+    echo "ℹ️  No --project given; using organization ${ORG_ID}'s only project: ${PROJECT}${PNAME:+ (${PNAME})}." >&2
+  elif [ "${PCOUNT:-0}" -eq 0 ]; then
+    echo "❌ Organization $ORG_ID has no projects — nothing to check." >&2
+    exit 2
+  else
+    echo "❌ Organization $ORG_ID has $PCOUNT projects — pass one with --project <id>:" >&2
+    printf '%s' "$ORG_JSON" | jq -r '.projects[] | "     \(.id)  \(.name)"' >&2
+    exit 2
+  fi
 fi
 
 # ---- 2. list recent PROJECT sessions ----

--- a/.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh
+++ b/.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# validate-c3d-session.sh
+#
+# Confirm that recent session data has landed on the Cognitive3D platform for a
+# given project, and print a few top-level details of the most recent session(s).
+# Works for any SDK/host (WebXR, Unity, Unreal, ...) — it only reads the backend.
+#
+# Auth: an ORGANIZATION API key (dashboard -> Organization Settings -> API Keys).
+# The organization ID is derived from the key automatically. A project ID is
+# required because an organization can contain multiple projects.
+#
+# The key is read from the C3D_ORG_API_KEY environment variable (preferred, so it
+# never appears in your shell history or the process list) or prompted for with
+# hidden input. It is never printed and is passed to curl via a mode-600 config file.
+#
+# Usage:
+#   export C3D_ORG_API_KEY='orgkey-xxxxxxxxxxxx'
+#   ./validate-c3d-session.sh --project 1234 [--env prod|dev] [--limit 5] [--session <id>] [--within <minutes>]
+#
+# Requires: bash, curl, jq.
+#
+set -euo pipefail
+
+ENVIRONMENT="prod"
+PROJECT=""
+LIMIT=5
+SESSION=""
+WITHIN=""   # optional: warn if the newest session is older than this many minutes
+
+usage() {
+  sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project) PROJECT="${2:-}"; shift 2;;
+    --env)     ENVIRONMENT="${2:-}"; shift 2;;
+    --limit)   LIMIT="${2:-}"; shift 2;;
+    --session) SESSION="${2:-}"; shift 2;;
+    --within)  WITHIN="${2:-}"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2;;
+  esac
+done
+
+command -v curl >/dev/null || { echo "error: curl is required" >&2; exit 1; }
+command -v jq   >/dev/null || { echo "error: jq is required (https://jqlang.github.io/jq/)" >&2; exit 1; }
+
+[ -n "$PROJECT" ] || { echo "error: --project <id> is required" >&2; usage; exit 2; }
+case "$PROJECT" in ''|*[!0-9]*) echo "error: --project must be numeric" >&2; exit 2;; esac
+case "$LIMIT"   in ''|*[!0-9]*) echo "error: --limit must be numeric" >&2; exit 2;; esac
+
+case "$ENVIRONMENT" in
+  prod) BASE="https://api.cognitive3d.com";;
+  dev)  BASE="https://api.c3ddev.com";;
+  *) echo "error: --env must be 'prod' or 'dev'" >&2; exit 2;;
+esac
+
+# ---- API key (never echoed) ----
+KEY="${C3D_ORG_API_KEY:-}"
+if [ -z "$KEY" ]; then
+  printf 'Cognitive3D organization API key (input hidden): ' >&2
+  read -rs KEY </dev/tty; echo >&2
+fi
+[ -n "$KEY" ] || { echo "error: no API key (set C3D_ORG_API_KEY or enter one when prompted)" >&2; exit 1; }
+case "$KEY" in orgkey-*) AUTH="$KEY";; *) AUTH="orgkey-$KEY";; esac
+
+# ---- curl config keeps the Authorization header out of argv / process list ----
+RC="$(mktemp)"; chmod 600 "$RC"; trap 'rm -f "$RC"' EXIT
+{ printf 'header = "Authorization: %s"\n' "$AUTH"; printf 'header = "Content-Type: application/json"\n'; } > "$RC"
+
+api_get()  { curl -fsS --config "$RC" "$BASE$1"; }
+api_post() { curl -sS  --config "$RC" -X POST "$BASE$1" -d "$2"; }
+
+# ---- 1. authenticate + derive organization id ----
+ORG_ID="$(api_get /v0/organizations/apiKeys/whoami 2>/dev/null | jq -r '.organizationId // empty' 2>/dev/null || true)"
+if [ -z "$ORG_ID" ]; then
+  echo "❌ Auth failed against ${BASE#https://}. Check the key is correct and that --env matches the key's environment (a prod key won't work on dev, or vice-versa)." >&2
+  exit 1
+fi
+
+# ---- 2. list recent PROJECT sessions ----
+BODY="$(jq -nc --argjson p "$PROJECT" --argjson l "$LIMIT" \
+  '{sessionType:"project", entityFilters:{projectId:$p}, page:0, limit:$l, sort:"desc", orderBy:{fieldName:"date", fieldParent:"session"}}')"
+RESP="$(api_post /v0/datasets/sessions/paginatedListQueries "$BODY" || true)"
+
+if ! printf '%s' "$RESP" | jq -e 'has("results")' >/dev/null 2>&1; then
+  echo "❌ Could not list sessions for project $PROJECT on ${ENVIRONMENT}:" >&2
+  printf '   %s\n' "$(printf '%s' "$RESP" | head -c 300)" >&2
+  echo "   (Is project $PROJECT in organization $ORG_ID?)" >&2
+  exit 1
+fi
+
+# ---- 3. report ----
+NOW="$(date +%s)"
+echo "Cognitive3D session check"
+echo "  organization : $ORG_ID   (derived from the API key)"
+echo "  project      : $PROJECT"
+echo "  environment  : $ENVIRONMENT  (${BASE#https://})"
+echo
+
+printf '%s' "$RESP" | jq -r --argjson now "$NOW" --arg session "$SESSION" '
+  def yn($b): if $b==true then "yes" else "no" end;
+  # jq'"'"'s `//` treats false like null, so use an explicit null check to keep false values.
+  def show($v): if $v == null then "?" else ($v|tostring) end;
+  def agemin($iso):
+    (try ($iso | sub("\\.[0-9]+Z$";"Z") | fromdateiso8601) catch null) as $e
+    | if $e == null then "?" else (($now - $e)/60 | floor) end;
+  ( .results | if ($session|length) > 0 then map(select(.sessionId == $session)) else . end ) as $rows
+  | if ($rows|length) == 0 then
+      (if ($session|length) > 0
+        then "⚠️  No session \($session) found for this project."
+        else "⚠️  No sessions found for this project yet — nothing has landed. Confirm the SDK is initialized with this project'"'"'s application key and that a session started + ended." end)
+    else
+      ( "✅ \(.count // ($rows|length)) session(s) exist for this project; showing the \($rows|length) most recent — data is landing on the platform.", "" ),
+      ( $rows[] |
+        "── \(.sessionId)",
+        "     landed      \(.date)   (~\(agemin(.date)) min ago)",
+        "     duration    \(((.duration // 0)/1000) | floor) s",
+        "     name        \(.friendlyName // "—")",
+        "     participant \(if ((.participantId // "")|length) > 0 then .participantId else (.properties["c3d.name"] // "—") end)",
+        "     captured    gaze=\(yn(.hasGaze)) events=\(yn(.hasEvent)) sensors=\(yn(.hasSensor)) dynamics=\(yn(.hasDynamic)) fixations=\(yn(.hasFixation))",
+        "     app / sdk   \(.properties["c3d.app.name"] // "—")  ·  engine=\(.properties["c3d.app.engine"] // "—")  ·  sdk=\(.properties["c3d.version"] // .properties["c3d.app.engine.version"] // "—")",
+        "     device      \((.properties["c3d.device.user_agent"] // .properties["c3d.device.model"] // "—") | tostring | .[0:70])",
+        "     tags        test=\(show(.properties["c3d.session_tag.test"]))  junk=\(show(.properties["c3d.session_tag.junk"]))",
+        ""
+      )
+    end'
+
+# ---- 4. exit status + optional recency check ----
+N="$(printf '%s' "$RESP" | jq -r --arg s "$SESSION" '(.results | if ($s|length)>0 then map(select(.sessionId==$s)) else . end) | length')"
+if [ "${N:-0}" -eq 0 ]; then exit 3; fi
+
+if [ -n "$WITHIN" ]; then
+  AGE="$(printf '%s' "$RESP" | jq -r --argjson now "$NOW" '
+    (.results[0].date // "" | select(length>0) | sub("\\.[0-9]+Z$";"Z") | fromdateiso8601) as $e | (($now - $e)/60 | floor)' 2>/dev/null || echo "")"
+  if [ -n "$AGE" ] && [ "$AGE" -gt "$WITHIN" ]; then
+    echo "⚠️  Newest session is ~${AGE} min old (older than --within ${WITHIN}). If you expected a session just now, it may not have landed yet." >&2
+    exit 4
+  fi
+fi
+exit 0

--- a/README.md
+++ b/README.md
@@ -98,3 +98,20 @@ The **[Cognitive3D WebXR SDK documentation](http://docs.cognitive3d.com/webxr/ge
 
 ## 🎮 Sample Projects
 For more detailed examples and complete project integrations (Mattercraft, ThreeJS, Wonderland Engine, etc..), please see our **[sample applications repository](https://github.com/CognitiveVR/c3d-webxr-sample-apps)** 
+
+## Coding Agent Skills
+
+This repo ships reusable skills under [`.claude/skills/`](.claude/skills/) — self-contained helpers (instructions plus a script) that a coding agent auto-discovers when you open the repo, so you can invoke them by name. The `SKILL.md` format originated with Claude Code and is now supported by a growing number of coding agents.
+
+Not using a coding agent (or yours doesn't support skills)? Each skill's `SKILL.md` documents the underlying script so you can run it directly.
+
+| Skill | What it does |
+| --- | --- |
+| [`validate-c3d-session`](.claude/skills/validate-c3d-session/) | Verify your session data has actually landed on the Cognitive3D platform. Give it your **organization API key** (dashboard → Organization Settings → API Keys — the organization ID is derived for you) and, optionally, a project ID; it reports whether recent sessions arrived plus a few top-level details (duration, name, participant, captured data types, device, test/junk tags). Read-only, works for any SDK/host, needs `curl` + `jq`. |
+
+Example:
+
+```bash
+export C3D_ORG_API_KEY='orgkey-…'   # keeps the key out of shell history
+.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh --project 1234
+```


### PR DESCRIPTION
Adds a checked-in, **client-facing** Claude Code skill that verifies session data has landed on the Cognitive3D platform for a project and reports a few top-level details. Generalized from the ad-hoc validation done during the WebXR work — usable for **any** SDK/host (WebXR, Unity, Unreal, …), not tied to this repo's app.

## Files
- `.claude/skills/validate-c3d-session/SKILL.md` — inputs, security, usage, manual curl fallback, notes.
- `.claude/skills/validate-c3d-session/scripts/validate-c3d-session.sh` — the worker (`curl` + `jq`).

## What it does
1. Reads an **organization API key** from `$C3D_ORG_API_KEY` (or a hidden prompt) — never echoed; passed to curl via a mode-600 config file so it can't leak into argv/history.
2. `GET /v0/organizations/apiKeys/whoami` → validates auth and **derives the organization ID** (not supplied by the user).
3. `POST /v0/datasets/sessions/paginatedListQueries` with `sessionType: "project"` + the **project ID** (required — orgs can have many projects) → most recent sessions.
4. Prints **PASS/FAIL** plus, per session: id, landed-at + age, duration, session name, participant, captured data types (gaze/events/sensors/dynamics/fixations), app/engine/sdk, device, and test/junk tags.

Flags: `--project <id>` (required), `--env prod|dev` (default prod), `--limit`, `--session <id>`, `--within <min>`. Exit codes: `0` found / `3` none / `1` error / `4` newest older than `--within`.

## Verified
- Live against **dev** (org 410, proj 691) and **prod** (org 4365, proj 5163) — lists recent sessions with correct details (incl. a fixed jq gotcha where `false // "?"` masked `false` tags).
- Wrong-env key → clean auth-failed message, exit 1.
- `bash -n` clean; markdownlint clean; deps `curl` + `jq`.

Not limited to junk/participant/name — the core assertion is "a recent session landed, here are the top-level details."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7n2ie4kYznuRSjGHjiJ4Y